### PR TITLE
scripts: Configure and use a nightly Rust toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 resolver = "2"
 members = ["clients/rust", "program"]
+
+[workspace.metadata.scripts.rustfmt.toolchain]
+channel = "nightly-2023-10-05"
+
+[workspace.metadata.scripts.clippy.toolchain]
+channel = "nightly-2023-10-05"

--- a/rust-nightly-toolchain.toml
+++ b/rust-nightly-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2023-10-05"

--- a/rust-nightly-toolchain.toml
+++ b/rust-nightly-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2023-10-05"

--- a/scripts/client/lint-rust.mjs
+++ b/scripts/client/lint-rust.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env zx
 import 'zx/globals';
-import { workingDirectory } from '../utils.mjs';
+import { getNightlyToolchain, workingDirectory } from '../utils.mjs';
 
-// Check the client using Clippy.
+// Check the client using nightly clippy.
 cd(path.join(workingDirectory, 'clients', 'rust'));
-await $`cargo clippy ${process.argv.slice(3)}`;
+await $`cargo +${getNightlyToolchain()} clippy ${process.argv.slice(3)}`;

--- a/scripts/client/lint-rust.mjs
+++ b/scripts/client/lint-rust.mjs
@@ -2,6 +2,6 @@
 import 'zx/globals';
 import { getClippyToolchain, workingDirectory } from '../utils.mjs';
 
-// Check the client using nightly clippy.
+// Check the client using clippy.
 cd(path.join(workingDirectory, 'clients', 'rust'));
-await $`cargo +${getClippyToolchain()} clippy ${process.argv.slice(3)}`;
+await $`cargo ${getClippyToolchain()} clippy ${process.argv.slice(3)}`;

--- a/scripts/client/lint-rust.mjs
+++ b/scripts/client/lint-rust.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env zx
 import 'zx/globals';
-import { getNightlyToolchain, workingDirectory } from '../utils.mjs';
+import { getClippyToolchain, workingDirectory } from '../utils.mjs';
 
 // Check the client using nightly clippy.
 cd(path.join(workingDirectory, 'clients', 'rust'));
-await $`cargo +${getNightlyToolchain()} clippy ${process.argv.slice(3)}`;
+await $`cargo +${getClippyToolchain()} clippy ${process.argv.slice(3)}`;

--- a/scripts/program/format.mjs
+++ b/scripts/program/format.mjs
@@ -9,5 +9,5 @@ import {
 // Format the programs.
 for (const folder of getProgramFolders()) {
   cd(`${path.join(workingDirectory, folder)}`);
-  await $`cargo +${getRustfmtToolchain()} fmt ${process.argv.slice(3)}`;
+  await $`cargo ${getRustfmtToolchain()} fmt ${process.argv.slice(3)}`;
 }

--- a/scripts/program/format.mjs
+++ b/scripts/program/format.mjs
@@ -1,9 +1,13 @@
 #!/usr/bin/env zx
 import 'zx/globals';
-import { workingDirectory, getProgramFolders } from '../utils.mjs';
+import {
+  workingDirectory,
+  getNightlyToolchain,
+  getProgramFolders,
+} from '../utils.mjs';
 
 // Format the programs.
 for (const folder of getProgramFolders()) {
   cd(`${path.join(workingDirectory, folder)}`);
-  await $`cargo fmt ${process.argv.slice(3)}`;
+  await $`cargo +${getNightlyToolchain()} fmt ${process.argv.slice(3)}`;
 }

--- a/scripts/program/format.mjs
+++ b/scripts/program/format.mjs
@@ -2,12 +2,12 @@
 import 'zx/globals';
 import {
   workingDirectory,
-  getNightlyToolchain,
+  getRustfmtToolchain,
   getProgramFolders,
 } from '../utils.mjs';
 
 // Format the programs.
 for (const folder of getProgramFolders()) {
   cd(`${path.join(workingDirectory, folder)}`);
-  await $`cargo +${getNightlyToolchain()} fmt ${process.argv.slice(3)}`;
+  await $`cargo +${getRustfmtToolchain()} fmt ${process.argv.slice(3)}`;
 }

--- a/scripts/program/lint.mjs
+++ b/scripts/program/lint.mjs
@@ -1,9 +1,13 @@
 #!/usr/bin/env zx
 import 'zx/globals';
-import { workingDirectory, getProgramFolders } from '../utils.mjs';
+import {
+  workingDirectory,
+  getNightlyToolchain,
+  getProgramFolders,
+} from '../utils.mjs';
 
 // Lint the programs using clippy.
 for (const folder of getProgramFolders()) {
   cd(`${path.join(workingDirectory, folder)}`);
-  await $`cargo clippy ${process.argv.slice(3)}`;
+  await $`cargo +${getNightlyToolchain()} clippy ${process.argv.slice(3)}`;
 }

--- a/scripts/program/lint.mjs
+++ b/scripts/program/lint.mjs
@@ -9,5 +9,5 @@ import {
 // Lint the programs using clippy.
 for (const folder of getProgramFolders()) {
   cd(`${path.join(workingDirectory, folder)}`);
-  await $`cargo +${getClippyToolchain()} clippy ${process.argv.slice(3)}`;
+  await $`cargo ${getClippyToolchain()} clippy ${process.argv.slice(3)}`;
 }

--- a/scripts/program/lint.mjs
+++ b/scripts/program/lint.mjs
@@ -2,12 +2,12 @@
 import 'zx/globals';
 import {
   workingDirectory,
-  getNightlyToolchain,
+  getClippyToolchain,
   getProgramFolders,
 } from '../utils.mjs';
 
 // Lint the programs using clippy.
 for (const folder of getProgramFolders()) {
   cd(`${path.join(workingDirectory, folder)}`);
-  await $`cargo +${getNightlyToolchain()} clippy ${process.argv.slice(3)}`;
+  await $`cargo +${getClippyToolchain()} clippy ${process.argv.slice(3)}`;
 }

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -82,15 +82,21 @@ export function getCargo(folder) {
   );
 }
 
+export function getCargoToolchainFromChannel(channel) {
+  return channel ? `+${channel}` : '';
+}
+
 export function getCargoMetadata(folder) {
   const cargo = getCargo(folder);
   return folder ? cargo?.package?.metadata : cargo?.workspace?.metadata;
 }
 
 export function getClippyToolchain(folder) {
-  return getCargoMetadata(folder).scripts?.clippy?.toolchain?.channel;
+  const channel = getCargoMetadata(folder).scripts?.clippy?.toolchain?.channel;
+  return getCargoToolchainFromChannel(channel);
 }
 
 export function getRustfmtToolchain(folder) {
-  return getCargoMetadata(folder).scripts?.rustfmt?.toolchain?.channel;
+  const channel = getCargoMetadata(folder).scripts?.rustfmt?.toolchain?.channel;
+  return getCargoToolchainFromChannel(channel);
 }

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -81,3 +81,12 @@ export function getCargo(folder) {
     )
   );
 }
+
+export function getNightlyToolchain() {
+  return parseToml(
+    fs.readFileSync(
+      path.join(workingDirectory, 'rust-nightly-toolchain.toml'),
+      'utf8'
+    )
+  ).toolchain.channel;
+}

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -82,11 +82,15 @@ export function getCargo(folder) {
   );
 }
 
-export function getNightlyToolchain() {
-  return parseToml(
-    fs.readFileSync(
-      path.join(workingDirectory, 'rust-nightly-toolchain.toml'),
-      'utf8'
-    )
-  ).toolchain.channel;
+export function getCargoMetadata(folder) {
+  const cargo = getCargo(folder);
+  return folder ? cargo?.package?.metadata : cargo?.workspace?.metadata;
+}
+
+export function getClippyToolchain(folder) {
+  return getCargoMetadata(folder).scripts?.clippy?.toolchain?.channel;
+}
+
+export function getRustfmtToolchain(folder) {
+  return getCargoMetadata(folder).scripts?.rustfmt?.toolchain?.channel;
 }


### PR DESCRIPTION
#### Problem

We want to use a nightly toolchain for certain checks, like clippy and rustfmt, but rust-toolchain.toml only allows for one toolchain to be configured.

#### Solution

Add a `rust-nightly-toolchain.toml` file at the top-level, which has the same format as a rust-toolchain.toml, in case cargo every supports multiple files.

Add a function to read the toolchain.

Use it.

cc @lorisleiva for any opinions. This adds another file at the top-level, which might not be super nice, but easy for people to find and configure.