### PR TITLE
Processor: `UpdateConfig`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 env:
   NODE_VERSION: 18

--- a/clients/js/src/generated/errors/stake.ts
+++ b/clients/js/src/generated/errors/stake.ts
@@ -18,6 +18,8 @@ export const STAKE_ERROR__INVALID_ACCOUNT_DATA_LENGTH = 0x3; // 3
 export const STAKE_ERROR__INVALID_MINT = 0x4; // 4
 /** MissingTransferHook: Missing transfer hook */
 export const STAKE_ERROR__MISSING_TRANSFER_HOOK = 0x5; // 5
+/** InvalidAuthority: Invalid authority */
+export const STAKE_ERROR__INVALID_AUTHORITY = 0x6; // 6
 /** CloseAuthorityNotNone: Close authority must be none */
 export const STAKE_ERROR__CLOSE_AUTHORITY_NOT_NONE = 0x6; // 6
 /** DelegateNotNone: Delegate must be none */
@@ -32,6 +34,7 @@ export type StakeError =
   | typeof STAKE_ERROR__CLOSE_AUTHORITY_NOT_NONE
   | typeof STAKE_ERROR__DELEGATE_NOT_NONE
   | typeof STAKE_ERROR__INVALID_ACCOUNT_DATA_LENGTH
+  | typeof STAKE_ERROR__INVALID_AUTHORITY
   | typeof STAKE_ERROR__INVALID_MINT
   | typeof STAKE_ERROR__INVALID_TOKEN_ACCOUNT_EXTENSION
   | typeof STAKE_ERROR__INVALID_TOKEN_OWNER
@@ -46,6 +49,7 @@ if (__DEV__) {
     [STAKE_ERROR__CLOSE_AUTHORITY_NOT_NONE]: `Close authority must be none`,
     [STAKE_ERROR__DELEGATE_NOT_NONE]: `Delegate must be none`,
     [STAKE_ERROR__INVALID_ACCOUNT_DATA_LENGTH]: `Invalid account data length`,
+    [STAKE_ERROR__INVALID_AUTHORITY]: `Invalid authority`,
     [STAKE_ERROR__INVALID_MINT]: `Invalid mint`,
     [STAKE_ERROR__INVALID_TOKEN_ACCOUNT_EXTENSION]: `Invalid token account extension`,
     [STAKE_ERROR__INVALID_TOKEN_OWNER]: `Invalid token owner`,

--- a/clients/js/src/generated/errors/stake.ts
+++ b/clients/js/src/generated/errors/stake.ts
@@ -20,6 +20,8 @@ export const STAKE_ERROR__INVALID_MINT = 0x4; // 4
 export const STAKE_ERROR__MISSING_TRANSFER_HOOK = 0x5; // 5
 /** InvalidAuthority: Invalid authority */
 export const STAKE_ERROR__INVALID_AUTHORITY = 0x6; // 6
+/** AuthorityNotSet: Authority is not set */
+export const STAKE_ERROR__AUTHORITY_NOT_SET = 0x7; // 7
 /** CloseAuthorityNotNone: Close authority must be none */
 export const STAKE_ERROR__CLOSE_AUTHORITY_NOT_NONE = 0x6; // 6
 /** DelegateNotNone: Delegate must be none */
@@ -31,6 +33,7 @@ export const STAKE_ERROR__MISSING_TOKEN_ACCOUNT_EXTENSIONS = 0x9; // 9
 
 export type StakeError =
   | typeof STAKE_ERROR__AMOUNT_GREATER_THAN_ZERO
+  | typeof STAKE_ERROR__AUTHORITY_NOT_SET
   | typeof STAKE_ERROR__CLOSE_AUTHORITY_NOT_NONE
   | typeof STAKE_ERROR__DELEGATE_NOT_NONE
   | typeof STAKE_ERROR__INVALID_ACCOUNT_DATA_LENGTH
@@ -46,6 +49,7 @@ let stakeErrorMessages: Record<StakeError, string> | undefined;
 if (__DEV__) {
   stakeErrorMessages = {
     [STAKE_ERROR__AMOUNT_GREATER_THAN_ZERO]: `Amount cannot be greater than zero`,
+    [STAKE_ERROR__AUTHORITY_NOT_SET]: `Authority is not set`,
     [STAKE_ERROR__CLOSE_AUTHORITY_NOT_NONE]: `Close authority must be none`,
     [STAKE_ERROR__DELEGATE_NOT_NONE]: `Delegate must be none`,
     [STAKE_ERROR__INVALID_ACCOUNT_DATA_LENGTH]: `Invalid account data length`,

--- a/clients/js/src/generated/errors/stake.ts
+++ b/clients/js/src/generated/errors/stake.ts
@@ -18,18 +18,16 @@ export const STAKE_ERROR__INVALID_ACCOUNT_DATA_LENGTH = 0x3; // 3
 export const STAKE_ERROR__INVALID_MINT = 0x4; // 4
 /** MissingTransferHook: Missing transfer hook */
 export const STAKE_ERROR__MISSING_TRANSFER_HOOK = 0x5; // 5
-/** InvalidAuthority: Invalid authority */
-export const STAKE_ERROR__INVALID_AUTHORITY = 0x6; // 6
-/** AuthorityNotSet: Authority is not set */
-export const STAKE_ERROR__AUTHORITY_NOT_SET = 0x7; // 7
 /** CloseAuthorityNotNone: Close authority must be none */
 export const STAKE_ERROR__CLOSE_AUTHORITY_NOT_NONE = 0x6; // 6
 /** DelegateNotNone: Delegate must be none */
 export const STAKE_ERROR__DELEGATE_NOT_NONE = 0x7; // 7
 /** InvalidTokenAccountExtension: Invalid token account extension */
 export const STAKE_ERROR__INVALID_TOKEN_ACCOUNT_EXTENSION = 0x8; // 8
-/** MissingTokenAccountExtensions: Missing token account extensions */
-export const STAKE_ERROR__MISSING_TOKEN_ACCOUNT_EXTENSIONS = 0x9; // 9
+/** InvalidAuthority: Invalid authority */
+export const STAKE_ERROR__INVALID_AUTHORITY = 0x9; // 9
+/** AuthorityNotSet: Authority is not set */
+export const STAKE_ERROR__AUTHORITY_NOT_SET = 0xa; // 10
 
 export type StakeError =
   | typeof STAKE_ERROR__AMOUNT_GREATER_THAN_ZERO
@@ -42,7 +40,6 @@ export type StakeError =
   | typeof STAKE_ERROR__INVALID_TOKEN_ACCOUNT_EXTENSION
   | typeof STAKE_ERROR__INVALID_TOKEN_OWNER
   | typeof STAKE_ERROR__INVALID_TRANSFER_HOOK_PROGRAM_ID
-  | typeof STAKE_ERROR__MISSING_TOKEN_ACCOUNT_EXTENSIONS
   | typeof STAKE_ERROR__MISSING_TRANSFER_HOOK;
 
 let stakeErrorMessages: Record<StakeError, string> | undefined;
@@ -58,7 +55,6 @@ if (__DEV__) {
     [STAKE_ERROR__INVALID_TOKEN_ACCOUNT_EXTENSION]: `Invalid token account extension`,
     [STAKE_ERROR__INVALID_TOKEN_OWNER]: `Invalid token owner`,
     [STAKE_ERROR__INVALID_TRANSFER_HOOK_PROGRAM_ID]: `Invalid transfer hook program id`,
-    [STAKE_ERROR__MISSING_TOKEN_ACCOUNT_EXTENSIONS]: `Missing token account extensions`,
     [STAKE_ERROR__MISSING_TRANSFER_HOOK]: `Missing transfer hook`,
   };
 }

--- a/clients/rust/src/generated/errors/stake.rs
+++ b/clients/rust/src/generated/errors/stake.rs
@@ -28,6 +28,9 @@ pub enum StakeError {
     /// 5 - Missing transfer hook
     #[error("Missing transfer hook")]
     MissingTransferHook = 0x5,
+    /// 6 - Invalid authority
+    #[error("Invalid authority")]
+    InvalidAuthority = 0x6,
     /// 6 - Close authority must be none
     #[error("Close authority must be none")]
     CloseAuthorityNotNone = 0x6,

--- a/clients/rust/src/generated/errors/stake.rs
+++ b/clients/rust/src/generated/errors/stake.rs
@@ -31,6 +31,9 @@ pub enum StakeError {
     /// 6 - Invalid authority
     #[error("Invalid authority")]
     InvalidAuthority = 0x6,
+    /// 7 - Authority is not set
+    #[error("Authority is not set")]
+    AuthorityNotSet = 0x7,
     /// 6 - Close authority must be none
     #[error("Close authority must be none")]
     CloseAuthorityNotNone = 0x6,

--- a/clients/rust/src/generated/errors/stake.rs
+++ b/clients/rust/src/generated/errors/stake.rs
@@ -28,12 +28,6 @@ pub enum StakeError {
     /// 5 - Missing transfer hook
     #[error("Missing transfer hook")]
     MissingTransferHook = 0x5,
-    /// 6 - Invalid authority
-    #[error("Invalid authority")]
-    InvalidAuthority = 0x6,
-    /// 7 - Authority is not set
-    #[error("Authority is not set")]
-    AuthorityNotSet = 0x7,
     /// 6 - Close authority must be none
     #[error("Close authority must be none")]
     CloseAuthorityNotNone = 0x6,
@@ -43,9 +37,12 @@ pub enum StakeError {
     /// 8 - Invalid token account extension
     #[error("Invalid token account extension")]
     InvalidTokenAccountExtension = 0x8,
-    /// 9 - Missing token account extensions
-    #[error("Missing token account extensions")]
-    MissingTokenAccountExtensions = 0x9,
+    /// 9 - Invalid authority
+    #[error("Invalid authority")]
+    InvalidAuthority = 0x9,
+    /// 10 - Authority is not set
+    #[error("Authority is not set")]
+    AuthorityNotSet = 0xA,
 }
 
 impl solana_program::program_error::PrintProgramError for StakeError {

--- a/clients/rust/tests/update_config.rs
+++ b/clients/rust/tests/update_config.rs
@@ -1,0 +1,349 @@
+#![cfg(feature = "test-sbf")]
+
+mod setup;
+
+use paladin_stake::{
+    accounts::Config,
+    errors::StakeError,
+    instructions::{InitializeConfigBuilder, UpdateConfigBuilder},
+    pdas::find_vault_pda,
+    types::ConfigField,
+};
+use setup::{create_mint, create_token, MINT_EXTENSIONS, TOKEN_ACCOUNT_EXTENSIONS};
+use solana_program_test::{tokio, ProgramTest};
+use solana_sdk::{
+    instruction::InstructionError,
+    signature::{Keypair, Signer},
+    system_instruction,
+    transaction::Transaction,
+};
+
+mod update_config {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn update_config() {
+        let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
+            .start_with_context()
+            .await;
+
+        // Given an empty config account and a mint.
+
+        let config = Keypair::new();
+        let authority = Keypair::new();
+
+        let mint = Keypair::new();
+        create_mint(
+            &mut context,
+            &mint,
+            &authority.pubkey(),
+            Some(&authority.pubkey()),
+            0,
+            MINT_EXTENSIONS,
+        )
+        .await
+        .unwrap();
+
+        let token = Keypair::new();
+        create_token(
+            &mut context,
+            &find_vault_pda(&config.pubkey()).0,
+            &token,
+            &mint.pubkey(),
+            TOKEN_ACCOUNT_EXTENSIONS,
+        )
+        .await
+        .unwrap();
+
+        // And we create a config.
+
+        let create_ix = system_instruction::create_account(
+            &context.payer.pubkey(),
+            &config.pubkey(),
+            context
+                .banks_client
+                .get_rent()
+                .await
+                .unwrap()
+                .minimum_balance(Config::LEN),
+            Config::LEN as u64,
+            &paladin_stake::ID,
+        );
+
+        let initialize_ix = InitializeConfigBuilder::new()
+            .config(config.pubkey())
+            .config_authority(authority.pubkey())
+            .slash_authority(authority.pubkey())
+            .mint(mint.pubkey())
+            .vault(token.pubkey())
+            .cooldown_time_seconds(1) // 1 second
+            .max_deactivation_basis_points(500) // 5%
+            .instruction();
+
+        let tx = Transaction::new_signed_with_payer(
+            &[create_ix, initialize_ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &config],
+            context.last_blockhash,
+        );
+        context.banks_client.process_transaction(tx).await.unwrap();
+
+        let account = get_account!(context, config.pubkey());
+        let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+        assert_eq!(config_account.cooldown_time_seconds, 1);
+
+        // When we update the config.
+
+        let ix = UpdateConfigBuilder::new()
+            .config(config.pubkey())
+            .config_authority(authority.pubkey())
+            .config_field(ConfigField::CooldownTimeSeconds(10)) // 10 seconds
+            .instruction();
+
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &authority],
+            context.last_blockhash,
+        );
+        context.banks_client.process_transaction(tx).await.unwrap();
+
+        // Then the config was updated.
+
+        let account = get_account!(context, config.pubkey());
+        let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+        assert_eq!(config_account.cooldown_time_seconds, 10);
+    }
+
+    #[tokio::test]
+    async fn fail_update_config_with_wrong_authority() {
+        let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
+            .start_with_context()
+            .await;
+
+        // Given an empty config account and a mint.
+
+        let config = Keypair::new();
+        let authority = Keypair::new();
+
+        let mint = Keypair::new();
+        create_mint(
+            &mut context,
+            &mint,
+            &authority.pubkey(),
+            Some(&authority.pubkey()),
+            0,
+            MINT_EXTENSIONS,
+        )
+        .await
+        .unwrap();
+
+        let token = Keypair::new();
+        create_token(
+            &mut context,
+            &find_vault_pda(&config.pubkey()).0,
+            &token,
+            &mint.pubkey(),
+            TOKEN_ACCOUNT_EXTENSIONS,
+        )
+        .await
+        .unwrap();
+
+        // And we create a config.
+
+        let create_ix = system_instruction::create_account(
+            &context.payer.pubkey(),
+            &config.pubkey(),
+            context
+                .banks_client
+                .get_rent()
+                .await
+                .unwrap()
+                .minimum_balance(Config::LEN),
+            Config::LEN as u64,
+            &paladin_stake::ID,
+        );
+
+        let initialize_ix = InitializeConfigBuilder::new()
+            .config(config.pubkey())
+            .config_authority(authority.pubkey())
+            .slash_authority(authority.pubkey())
+            .mint(mint.pubkey())
+            .vault(token.pubkey())
+            .cooldown_time_seconds(1) // 1 second
+            .max_deactivation_basis_points(500) // 5%
+            .instruction();
+
+        let tx = Transaction::new_signed_with_payer(
+            &[create_ix, initialize_ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &config],
+            context.last_blockhash,
+        );
+        context.banks_client.process_transaction(tx).await.unwrap();
+
+        let account = get_account!(context, config.pubkey());
+        let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+        assert_eq!(config_account.cooldown_time_seconds, 1);
+
+        // When we try to update the config with a wrong authority.
+        let fake_authority = Keypair::new();
+
+        let ix = UpdateConfigBuilder::new()
+            .config(config.pubkey())
+            .config_authority(fake_authority.pubkey())
+            .config_field(ConfigField::CooldownTimeSeconds(10)) // 10 seconds
+            .instruction();
+
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &fake_authority],
+            context.last_blockhash,
+        );
+
+        let err = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
+
+        // Then we expect an error.
+
+        assert_custom_error!(err, StakeError::InvalidAuthority);
+    }
+
+    #[tokio::test]
+    async fn fail_update_config_non_existing() {
+        let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
+            .start_with_context()
+            .await;
+
+        // Given an non-existing config account and a mint.
+
+        let config = Keypair::new();
+        let authority = Keypair::new();
+
+        let mint = Keypair::new();
+        create_mint(
+            &mut context,
+            &mint,
+            &authority.pubkey(),
+            Some(&authority.pubkey()),
+            0,
+            MINT_EXTENSIONS,
+        )
+        .await
+        .unwrap();
+
+        let token = Keypair::new();
+        create_token(
+            &mut context,
+            &find_vault_pda(&config.pubkey()).0,
+            &token,
+            &mint.pubkey(),
+            TOKEN_ACCOUNT_EXTENSIONS,
+        )
+        .await
+        .unwrap();
+
+        // And we try to update a non-existing config.
+
+        let ix = UpdateConfigBuilder::new()
+            .config(config.pubkey())
+            .config_authority(authority.pubkey())
+            .config_field(ConfigField::CooldownTimeSeconds(10))
+            .instruction();
+
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &authority],
+            context.last_blockhash,
+        );
+
+        let err = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
+
+        // Then we expect an error.
+
+        assert_instruction_error!(err, InstructionError::InvalidAccountOwner);
+    }
+
+    #[tokio::test]
+    async fn fail_update_with_uninitialized_config() {
+        let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
+            .start_with_context()
+            .await;
+
+        // Given an empty config account and a mint.
+
+        let config = Keypair::new();
+        let authority = Keypair::new();
+
+        let mint = Keypair::new();
+        create_mint(
+            &mut context,
+            &mint,
+            &authority.pubkey(),
+            Some(&authority.pubkey()),
+            0,
+            MINT_EXTENSIONS,
+        )
+        .await
+        .unwrap();
+
+        let token = Keypair::new();
+        create_token(
+            &mut context,
+            &find_vault_pda(&config.pubkey()).0,
+            &token,
+            &mint.pubkey(),
+            TOKEN_ACCOUNT_EXTENSIONS,
+        )
+        .await
+        .unwrap();
+
+        // When we try to update the empty config.
+
+        let create_ix = system_instruction::create_account(
+            &context.payer.pubkey(),
+            &config.pubkey(),
+            context
+                .banks_client
+                .get_rent()
+                .await
+                .unwrap()
+                .minimum_balance(Config::LEN),
+            Config::LEN as u64,
+            &paladin_stake::ID,
+        );
+
+        let update_ix = UpdateConfigBuilder::new()
+            .config(config.pubkey())
+            .config_authority(authority.pubkey())
+            .config_field(ConfigField::CooldownTimeSeconds(10))
+            .instruction();
+
+        let tx = Transaction::new_signed_with_payer(
+            &[create_ix, update_ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &config, &authority],
+            context.last_blockhash,
+        );
+
+        let err = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
+
+        // Then we expect an error.
+
+        assert_instruction_error!(err, InstructionError::UninitializedAccount);
+    }
+}

--- a/clients/rust/tests/update_config.rs
+++ b/clients/rust/tests/update_config.rs
@@ -13,337 +13,480 @@ use setup::{create_mint, create_token, MINT_EXTENSIONS, TOKEN_ACCOUNT_EXTENSIONS
 use solana_program_test::{tokio, ProgramTest};
 use solana_sdk::{
     instruction::InstructionError,
+    pubkey::Pubkey,
     signature::{Keypair, Signer},
     system_instruction,
     transaction::Transaction,
 };
 
-mod update_config {
+#[tokio::test]
+async fn update_cooldown_time_config() {
+    let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
+        .start_with_context()
+        .await;
 
-    use super::*;
+    // Given an empty config account and a mint.
 
-    #[tokio::test]
-    async fn update_config() {
-        let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
-            .start_with_context()
-            .await;
+    let config = Keypair::new();
+    let authority = Keypair::new();
 
-        // Given an empty config account and a mint.
+    let mint = Keypair::new();
+    create_mint(
+        &mut context,
+        &mint,
+        &authority.pubkey(),
+        Some(&authority.pubkey()),
+        0,
+        MINT_EXTENSIONS,
+    )
+    .await
+    .unwrap();
 
-        let config = Keypair::new();
-        let authority = Keypair::new();
+    let token = Keypair::new();
+    create_token(
+        &mut context,
+        &find_vault_pda(&config.pubkey()).0,
+        &token,
+        &mint.pubkey(),
+        TOKEN_ACCOUNT_EXTENSIONS,
+    )
+    .await
+    .unwrap();
 
-        let mint = Keypair::new();
-        create_mint(
-            &mut context,
-            &mint,
-            &authority.pubkey(),
-            Some(&authority.pubkey()),
-            0,
-            MINT_EXTENSIONS,
-        )
-        .await
-        .unwrap();
+    // And we create a config.
 
-        let token = Keypair::new();
-        create_token(
-            &mut context,
-            &find_vault_pda(&config.pubkey()).0,
-            &token,
-            &mint.pubkey(),
-            TOKEN_ACCOUNT_EXTENSIONS,
-        )
-        .await
-        .unwrap();
-
-        // And we create a config.
-
-        let create_ix = system_instruction::create_account(
-            &context.payer.pubkey(),
-            &config.pubkey(),
-            context
-                .banks_client
-                .get_rent()
-                .await
-                .unwrap()
-                .minimum_balance(Config::LEN),
-            Config::LEN as u64,
-            &paladin_stake::ID,
-        );
-
-        let initialize_ix = InitializeConfigBuilder::new()
-            .config(config.pubkey())
-            .config_authority(authority.pubkey())
-            .slash_authority(authority.pubkey())
-            .mint(mint.pubkey())
-            .vault(token.pubkey())
-            .cooldown_time_seconds(1) // 1 second
-            .max_deactivation_basis_points(500) // 5%
-            .instruction();
-
-        let tx = Transaction::new_signed_with_payer(
-            &[create_ix, initialize_ix],
-            Some(&context.payer.pubkey()),
-            &[&context.payer, &config],
-            context.last_blockhash,
-        );
-        context.banks_client.process_transaction(tx).await.unwrap();
-
-        let account = get_account!(context, config.pubkey());
-        let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
-        assert_eq!(config_account.cooldown_time_seconds, 1);
-
-        // When we update the config.
-
-        let ix = UpdateConfigBuilder::new()
-            .config(config.pubkey())
-            .config_authority(authority.pubkey())
-            .config_field(ConfigField::CooldownTimeSeconds(10)) // 10 seconds
-            .instruction();
-
-        let tx = Transaction::new_signed_with_payer(
-            &[ix],
-            Some(&context.payer.pubkey()),
-            &[&context.payer, &authority],
-            context.last_blockhash,
-        );
-        context.banks_client.process_transaction(tx).await.unwrap();
-
-        // Then the config was updated.
-
-        let account = get_account!(context, config.pubkey());
-        let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
-        assert_eq!(config_account.cooldown_time_seconds, 10);
-    }
-
-    #[tokio::test]
-    async fn fail_update_config_with_wrong_authority() {
-        let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
-            .start_with_context()
-            .await;
-
-        // Given an empty config account and a mint.
-
-        let config = Keypair::new();
-        let authority = Keypair::new();
-
-        let mint = Keypair::new();
-        create_mint(
-            &mut context,
-            &mint,
-            &authority.pubkey(),
-            Some(&authority.pubkey()),
-            0,
-            MINT_EXTENSIONS,
-        )
-        .await
-        .unwrap();
-
-        let token = Keypair::new();
-        create_token(
-            &mut context,
-            &find_vault_pda(&config.pubkey()).0,
-            &token,
-            &mint.pubkey(),
-            TOKEN_ACCOUNT_EXTENSIONS,
-        )
-        .await
-        .unwrap();
-
-        // And we create a config.
-
-        let create_ix = system_instruction::create_account(
-            &context.payer.pubkey(),
-            &config.pubkey(),
-            context
-                .banks_client
-                .get_rent()
-                .await
-                .unwrap()
-                .minimum_balance(Config::LEN),
-            Config::LEN as u64,
-            &paladin_stake::ID,
-        );
-
-        let initialize_ix = InitializeConfigBuilder::new()
-            .config(config.pubkey())
-            .config_authority(authority.pubkey())
-            .slash_authority(authority.pubkey())
-            .mint(mint.pubkey())
-            .vault(token.pubkey())
-            .cooldown_time_seconds(1) // 1 second
-            .max_deactivation_basis_points(500) // 5%
-            .instruction();
-
-        let tx = Transaction::new_signed_with_payer(
-            &[create_ix, initialize_ix],
-            Some(&context.payer.pubkey()),
-            &[&context.payer, &config],
-            context.last_blockhash,
-        );
-        context.banks_client.process_transaction(tx).await.unwrap();
-
-        let account = get_account!(context, config.pubkey());
-        let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
-        assert_eq!(config_account.cooldown_time_seconds, 1);
-
-        // When we try to update the config with a wrong authority.
-        let fake_authority = Keypair::new();
-
-        let ix = UpdateConfigBuilder::new()
-            .config(config.pubkey())
-            .config_authority(fake_authority.pubkey())
-            .config_field(ConfigField::CooldownTimeSeconds(10)) // 10 seconds
-            .instruction();
-
-        let tx = Transaction::new_signed_with_payer(
-            &[ix],
-            Some(&context.payer.pubkey()),
-            &[&context.payer, &fake_authority],
-            context.last_blockhash,
-        );
-
-        let err = context
+    let create_ix = system_instruction::create_account(
+        &context.payer.pubkey(),
+        &config.pubkey(),
+        context
             .banks_client
-            .process_transaction(tx)
+            .get_rent()
             .await
-            .unwrap_err();
+            .unwrap()
+            .minimum_balance(Config::LEN),
+        Config::LEN as u64,
+        &paladin_stake::ID,
+    );
 
-        // Then we expect an error.
+    let initialize_ix = InitializeConfigBuilder::new()
+        .config(config.pubkey())
+        .config_authority(authority.pubkey())
+        .slash_authority(authority.pubkey())
+        .mint(mint.pubkey())
+        .vault(token.pubkey())
+        .cooldown_time_seconds(1) // 1 second
+        .max_deactivation_basis_points(500) // 5%
+        .instruction();
 
-        assert_custom_error!(err, StakeError::InvalidAuthority);
-    }
+    let tx = Transaction::new_signed_with_payer(
+        &[create_ix, initialize_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &config],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
 
-    #[tokio::test]
-    async fn fail_update_config_non_existing() {
-        let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
-            .start_with_context()
-            .await;
+    let account = get_account!(context, config.pubkey());
+    let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(config_account.cooldown_time_seconds, 1);
 
-        // Given an non-existing config account and a mint.
+    // When we update the cooldown time config.
 
-        let config = Keypair::new();
-        let authority = Keypair::new();
+    let ix = UpdateConfigBuilder::new()
+        .config(config.pubkey())
+        .config_authority(authority.pubkey())
+        .config_field(ConfigField::CooldownTimeSeconds(10)) // 10 seconds
+        .instruction();
 
-        let mint = Keypair::new();
-        create_mint(
-            &mut context,
-            &mint,
-            &authority.pubkey(),
-            Some(&authority.pubkey()),
-            0,
-            MINT_EXTENSIONS,
-        )
-        .await
-        .unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &authority],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
 
-        let token = Keypair::new();
-        create_token(
-            &mut context,
-            &find_vault_pda(&config.pubkey()).0,
-            &token,
-            &mint.pubkey(),
-            TOKEN_ACCOUNT_EXTENSIONS,
-        )
-        .await
-        .unwrap();
+    // Then the cooldown time was updated.
 
-        // And we try to update a non-existing config.
+    let account = get_account!(context, config.pubkey());
+    let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(config_account.cooldown_time_seconds, 10);
+    assert_eq!(config_account.max_deactivation_basis_points, 500);
+}
 
-        let ix = UpdateConfigBuilder::new()
-            .config(config.pubkey())
-            .config_authority(authority.pubkey())
-            .config_field(ConfigField::CooldownTimeSeconds(10))
-            .instruction();
+#[tokio::test]
+async fn update_max_deactivation_basis_points_config() {
+    let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
+        .start_with_context()
+        .await;
 
-        let tx = Transaction::new_signed_with_payer(
-            &[ix],
-            Some(&context.payer.pubkey()),
-            &[&context.payer, &authority],
-            context.last_blockhash,
-        );
+    // Given an empty config account and a mint.
 
-        let err = context
+    let config = Keypair::new();
+    let authority = Keypair::new();
+
+    let mint = Keypair::new();
+    create_mint(
+        &mut context,
+        &mint,
+        &authority.pubkey(),
+        Some(&authority.pubkey()),
+        0,
+        MINT_EXTENSIONS,
+    )
+    .await
+    .unwrap();
+
+    let token = Keypair::new();
+    create_token(
+        &mut context,
+        &find_vault_pda(&config.pubkey()).0,
+        &token,
+        &mint.pubkey(),
+        TOKEN_ACCOUNT_EXTENSIONS,
+    )
+    .await
+    .unwrap();
+
+    // And we create a config.
+
+    let create_ix = system_instruction::create_account(
+        &context.payer.pubkey(),
+        &config.pubkey(),
+        context
             .banks_client
-            .process_transaction(tx)
+            .get_rent()
             .await
-            .unwrap_err();
+            .unwrap()
+            .minimum_balance(Config::LEN),
+        Config::LEN as u64,
+        &paladin_stake::ID,
+    );
 
-        // Then we expect an error.
+    let initialize_ix = InitializeConfigBuilder::new()
+        .config(config.pubkey())
+        .config_authority(authority.pubkey())
+        .slash_authority(authority.pubkey())
+        .mint(mint.pubkey())
+        .vault(token.pubkey())
+        .cooldown_time_seconds(1)
+        .max_deactivation_basis_points(500) // 5%
+        .instruction();
 
-        assert_instruction_error!(err, InstructionError::InvalidAccountOwner);
-    }
+    let tx = Transaction::new_signed_with_payer(
+        &[create_ix, initialize_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &config],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
 
-    #[tokio::test]
-    async fn fail_update_with_uninitialized_config() {
-        let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
-            .start_with_context()
-            .await;
+    let account = get_account!(context, config.pubkey());
+    let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(config_account.cooldown_time_seconds, 1);
 
-        // Given an empty config account and a mint.
+    // When we update the max deactivation basis points config.
 
-        let config = Keypair::new();
-        let authority = Keypair::new();
+    let ix = UpdateConfigBuilder::new()
+        .config(config.pubkey())
+        .config_authority(authority.pubkey())
+        .config_field(ConfigField::MaxDeactivationBasisPoints(1000)) // 10%
+        .instruction();
 
-        let mint = Keypair::new();
-        create_mint(
-            &mut context,
-            &mint,
-            &authority.pubkey(),
-            Some(&authority.pubkey()),
-            0,
-            MINT_EXTENSIONS,
-        )
-        .await
-        .unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &authority],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
 
-        let token = Keypair::new();
-        create_token(
-            &mut context,
-            &find_vault_pda(&config.pubkey()).0,
-            &token,
-            &mint.pubkey(),
-            TOKEN_ACCOUNT_EXTENSIONS,
-        )
-        .await
-        .unwrap();
+    // Then the max deactivation basis pointswas updated.
 
-        // When we try to update the empty config.
+    let account = get_account!(context, config.pubkey());
+    let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(config_account.cooldown_time_seconds, 1);
+    assert_eq!(config_account.max_deactivation_basis_points, 1000);
+}
 
-        let create_ix = system_instruction::create_account(
-            &context.payer.pubkey(),
-            &config.pubkey(),
-            context
-                .banks_client
-                .get_rent()
-                .await
-                .unwrap()
-                .minimum_balance(Config::LEN),
-            Config::LEN as u64,
-            &paladin_stake::ID,
-        );
+#[tokio::test]
+async fn fail_update_config_with_wrong_authority() {
+    let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
+        .start_with_context()
+        .await;
 
-        let update_ix = UpdateConfigBuilder::new()
-            .config(config.pubkey())
-            .config_authority(authority.pubkey())
-            .config_field(ConfigField::CooldownTimeSeconds(10))
-            .instruction();
+    // Given an empty config account and a mint.
 
-        let tx = Transaction::new_signed_with_payer(
-            &[create_ix, update_ix],
-            Some(&context.payer.pubkey()),
-            &[&context.payer, &config, &authority],
-            context.last_blockhash,
-        );
+    let config = Keypair::new();
+    let authority = Keypair::new();
 
-        let err = context
+    let mint = Keypair::new();
+    create_mint(
+        &mut context,
+        &mint,
+        &authority.pubkey(),
+        Some(&authority.pubkey()),
+        0,
+        MINT_EXTENSIONS,
+    )
+    .await
+    .unwrap();
+
+    let token = Keypair::new();
+    create_token(
+        &mut context,
+        &find_vault_pda(&config.pubkey()).0,
+        &token,
+        &mint.pubkey(),
+        TOKEN_ACCOUNT_EXTENSIONS,
+    )
+    .await
+    .unwrap();
+
+    // And we create a config.
+
+    let create_ix = system_instruction::create_account(
+        &context.payer.pubkey(),
+        &config.pubkey(),
+        context
             .banks_client
-            .process_transaction(tx)
+            .get_rent()
             .await
-            .unwrap_err();
+            .unwrap()
+            .minimum_balance(Config::LEN),
+        Config::LEN as u64,
+        &paladin_stake::ID,
+    );
 
-        // Then we expect an error.
+    let initialize_ix = InitializeConfigBuilder::new()
+        .config(config.pubkey())
+        .config_authority(authority.pubkey())
+        .slash_authority(authority.pubkey())
+        .mint(mint.pubkey())
+        .vault(token.pubkey())
+        .cooldown_time_seconds(1) // 1 second
+        .max_deactivation_basis_points(500) // 5%
+        .instruction();
 
-        assert_instruction_error!(err, InstructionError::UninitializedAccount);
-    }
+    let tx = Transaction::new_signed_with_payer(
+        &[create_ix, initialize_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &config],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    let account = get_account!(context, config.pubkey());
+    let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(config_account.cooldown_time_seconds, 1);
+
+    // When we try to update the config with a wrong authority.
+    let fake_authority = Keypair::new();
+
+    let ix = UpdateConfigBuilder::new()
+        .config(config.pubkey())
+        .config_authority(fake_authority.pubkey())
+        .config_field(ConfigField::CooldownTimeSeconds(10)) // 10 seconds
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &fake_authority],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    // Then we expect an error.
+
+    assert_custom_error!(err, StakeError::InvalidAuthority);
+}
+
+#[tokio::test]
+async fn fail_update_config_non_existing() {
+    let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
+        .start_with_context()
+        .await;
+
+    // Given an non-existing config account.
+
+    let config = Keypair::new();
+    let authority = Keypair::new();
+
+    // And we try to update a non-existing config.
+
+    let ix = UpdateConfigBuilder::new()
+        .config(config.pubkey())
+        .config_authority(authority.pubkey())
+        .config_field(ConfigField::CooldownTimeSeconds(10))
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &authority],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    // Then we expect an error.
+
+    assert_instruction_error!(err, InstructionError::InvalidAccountOwner);
+}
+
+#[tokio::test]
+async fn fail_update_with_uninitialized_config() {
+    let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
+        .start_with_context()
+        .await;
+
+    // Given an empty config account.
+
+    let config = Keypair::new();
+    let authority = Keypair::new();
+
+    let create_ix = system_instruction::create_account(
+        &context.payer.pubkey(),
+        &config.pubkey(),
+        context
+            .banks_client
+            .get_rent()
+            .await
+            .unwrap()
+            .minimum_balance(Config::LEN),
+        Config::LEN as u64,
+        &paladin_stake::ID,
+    );
+
+    // When we try to update the empty config.
+
+    let update_ix = UpdateConfigBuilder::new()
+        .config(config.pubkey())
+        .config_authority(authority.pubkey())
+        .config_field(ConfigField::CooldownTimeSeconds(10))
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create_ix, update_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &config, &authority],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    // Then we expect an error.
+
+    assert_instruction_error!(err, InstructionError::UninitializedAccount);
+}
+
+#[tokio::test]
+async fn fail_update_config_with_no_authority_set() {
+    let mut context = ProgramTest::new("stake_program", paladin_stake::ID, None)
+        .start_with_context()
+        .await;
+
+    // Given an empty config account and a mint.
+
+    let config = Keypair::new();
+    let authority = Keypair::new();
+
+    let mint = Keypair::new();
+    create_mint(
+        &mut context,
+        &mint,
+        &authority.pubkey(),
+        Some(&authority.pubkey()),
+        0,
+        MINT_EXTENSIONS,
+    )
+    .await
+    .unwrap();
+
+    let token = Keypair::new();
+    create_token(
+        &mut context,
+        &find_vault_pda(&config.pubkey()).0,
+        &token,
+        &mint.pubkey(),
+        TOKEN_ACCOUNT_EXTENSIONS,
+    )
+    .await
+    .unwrap();
+
+    // And we create a config.
+
+    let create_ix = system_instruction::create_account(
+        &context.payer.pubkey(),
+        &config.pubkey(),
+        context
+            .banks_client
+            .get_rent()
+            .await
+            .unwrap()
+            .minimum_balance(Config::LEN),
+        Config::LEN as u64,
+        &paladin_stake::ID,
+    );
+
+    let initialize_ix = InitializeConfigBuilder::new()
+        .config(config.pubkey())
+        .config_authority(Pubkey::default()) // <- no authority
+        .slash_authority(authority.pubkey())
+        .mint(mint.pubkey())
+        .vault(token.pubkey())
+        .cooldown_time_seconds(1)
+        .max_deactivation_basis_points(500)
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create_ix, initialize_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &config],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    let account = get_account!(context, config.pubkey());
+    let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(config_account.cooldown_time_seconds, 1);
+
+    // When we try to update the config when no authority is set
+
+    let ix = UpdateConfigBuilder::new()
+        .config(config.pubkey())
+        .config_authority(authority.pubkey())
+        .config_field(ConfigField::CooldownTimeSeconds(10))
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &authority],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    // Then we expect an error.
+
+    assert_custom_error!(err, StakeError::AuthorityNotSet);
 }

--- a/clients/rust/tests/update_config.rs
+++ b/clients/rust/tests/update_config.rs
@@ -9,7 +9,7 @@ use paladin_stake::{
     pdas::find_vault_pda,
     types::ConfigField,
 };
-use setup::{create_mint, create_token, MINT_EXTENSIONS, TOKEN_ACCOUNT_EXTENSIONS};
+use setup::{create_mint, create_token_account, MINT_EXTENSIONS, TOKEN_ACCOUNT_EXTENSIONS};
 use solana_program_test::{tokio, ProgramTest};
 use solana_sdk::{
     instruction::InstructionError,
@@ -43,7 +43,7 @@ async fn update_cooldown_time_config() {
     .unwrap();
 
     let token = Keypair::new();
-    create_token(
+    create_token_account(
         &mut context,
         &find_vault_pda(&config.pubkey()).0,
         &token,
@@ -138,7 +138,7 @@ async fn update_max_deactivation_basis_points_config() {
     .unwrap();
 
     let token = Keypair::new();
-    create_token(
+    create_token_account(
         &mut context,
         &find_vault_pda(&config.pubkey()).0,
         &token,
@@ -233,7 +233,7 @@ async fn fail_update_config_with_wrong_authority() {
     .unwrap();
 
     let token = Keypair::new();
-    create_token(
+    create_token_account(
         &mut context,
         &find_vault_pda(&config.pubkey()).0,
         &token,
@@ -418,7 +418,7 @@ async fn fail_update_config_with_no_authority_set() {
     .unwrap();
 
     let token = Keypair::new();
-    create_token(
+    create_token_account(
         &mut context,
         &find_vault_pda(&config.pubkey()).0,
         &token,

--- a/program/idl.json
+++ b/program/idl.json
@@ -804,6 +804,11 @@
       "msg": "Invalid authority"
     },
     {
+      "code": 7,
+      "name": "AuthorityNotSet",
+      "msg": "Authority is not set"
+    },
+    {
       "code": 6,
       "name": "CloseAuthorityNotNone",
       "msg": "Close authority must be none"

--- a/program/idl.json
+++ b/program/idl.json
@@ -800,6 +800,11 @@
     },
     {
       "code": 6,
+      "name": "InvalidAuthority",
+      "msg": "Invalid authority"
+    },
+    {
+      "code": 6,
       "name": "CloseAuthorityNotNone",
       "msg": "Close authority must be none"
     },

--- a/program/idl.json
+++ b/program/idl.json
@@ -800,16 +800,6 @@
     },
     {
       "code": 6,
-      "name": "InvalidAuthority",
-      "msg": "Invalid authority"
-    },
-    {
-      "code": 7,
-      "name": "AuthorityNotSet",
-      "msg": "Authority is not set"
-    },
-    {
-      "code": 6,
       "name": "CloseAuthorityNotNone",
       "msg": "Close authority must be none"
     },
@@ -825,8 +815,13 @@
     },
     {
       "code": 9,
-      "name": "MissingTokenAccountExtensions",
-      "msg": "Missing token account extensions"
+      "name": "InvalidAuthority",
+      "msg": "Invalid authority"
+    },
+    {
+      "code": 10,
+      "name": "AuthorityNotSet",
+      "msg": "Authority is not set"
     }
   ],
   "metadata": {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -44,6 +44,10 @@ pub enum StakeError {
     /// 8 - Invalid token account extension
     #[error("Invalid token account extension")]
     InvalidTokenAccountExtension,
+
+    /// 7 - Authority is not set
+    #[error("Authority is not set")]
+    AuthorityNotSet,
 }
 
 impl PrintProgramError for StakeError {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -45,7 +45,11 @@ pub enum StakeError {
     #[error("Invalid token account extension")]
     InvalidTokenAccountExtension,
 
-    /// 7 - Authority is not set
+    /// 9 - Invalid authority
+    #[error("Invalid authority")]
+    InvalidAuthority,
+
+    /// 10 - Authority is not set
     #[error("Authority is not set")]
     AuthorityNotSet,
 }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -44,10 +44,6 @@ pub enum StakeError {
     /// 8 - Invalid token account extension
     #[error("Invalid token account extension")]
     InvalidTokenAccountExtension,
-
-    /// 9 - Missing token account extensions
-    #[error("Missing token account extensions")]
-    MissingTokenAccountExtensions,
 }
 
 impl PrintProgramError for StakeError {

--- a/program/src/processor/update_config.rs
+++ b/program/src/processor/update_config.rs
@@ -1,8 +1,15 @@
-use solana_program::{entrypoint::ProgramResult, pubkey::Pubkey};
+use solana_program::{
+    clock::UnixTimestamp, entrypoint::ProgramResult, program_error::ProgramError, pubkey::Pubkey,
+};
 
-use crate::instruction::{
-    accounts::{Context, UpdateConfigAccounts},
-    ConfigField,
+use crate::{
+    error::StakeError,
+    instruction::{
+        accounts::{Context, UpdateConfigAccounts},
+        ConfigField,
+    },
+    require,
+    state::Config,
 };
 
 /// Updates configuration parameters.
@@ -12,9 +19,66 @@ use crate::instruction::{
 ///   0. `[w]` config
 ///   1. `[s]` config_authority
 pub fn process_update_config(
-    _program_id: &Pubkey,
-    _ctx: Context<UpdateConfigAccounts>,
-    _field: ConfigField,
+    program_id: &Pubkey,
+    ctx: Context<UpdateConfigAccounts>,
+    field: ConfigField,
 ) -> ProgramResult {
+    // Accounts validation.
+
+    // 1. config
+    // - owner must the stake program
+    // - must be initialized
+
+    require!(
+        ctx.accounts.config.owner == program_id,
+        ProgramError::InvalidAccountOwner,
+        "config"
+    );
+
+    let data = &mut ctx.accounts.config.try_borrow_mut_data()?;
+
+    let config = bytemuck::try_from_bytes_mut::<Config>(data)
+        .map_err(|_error| ProgramError::InvalidAccountData)?;
+
+    require!(
+        config.is_initialized(),
+        ProgramError::UninitializedAccount,
+        "config"
+    );
+
+    let authority: Option<Pubkey> = config.authority.into();
+
+    if let Some(authority) = authority {
+        // 2. config_authority
+        // - config_authority must match the authority in the config
+        // - must be a signer
+
+        require!(
+            ctx.accounts.config_authority.key == &authority,
+            StakeError::InvalidAuthority,
+            "config_authority"
+        );
+
+        require!(
+            ctx.accounts.config_authority.is_signer,
+            ProgramError::MissingRequiredSignature,
+            "config_authority"
+        );
+
+        // Updates the config account.
+
+        match field {
+            ConfigField::CooldownTimeSeconds(seconds) => {
+                config.cooldown_time_seconds = seconds as UnixTimestamp;
+            }
+            ConfigField::MaxDeactivationBasisPoints(points) => {
+                config.max_deactivation_basis_points = points;
+            }
+        }
+    } else {
+        // TODO: do we need to log a message to say that the config authority is not set
+        // and the update did not happen? Or fail the transaction?
+    }
+
     Ok(())
 }

--- a/program/src/processor/update_config.rs
+++ b/program/src/processor/update_config.rs
@@ -3,6 +3,7 @@ use solana_program::{
 };
 
 use crate::{
+    err,
     error::StakeError,
     instruction::{
         accounts::{Context, UpdateConfigAccounts},
@@ -76,8 +77,7 @@ pub fn process_update_config(
             }
         }
     } else {
-        // TODO: do we need to log a message to say that the config authority is not set
-        // and the update did not happen? Or fail the transaction?
+        return err!(StakeError::AuthorityNotSet);
     }
 
     Ok(())


### PR DESCRIPTION
This PR adds the processor for the `UpdateConfig` instruction.

The instruction update the staking parameters of the the Stake config account.

> [!NOTE]
> Rust tests are under the client crate since they use the instruction builders generated by Kinobi.