### PR TITLE
Update stake account derivation

### DIFF
--- a/clients/js/src/generated/accounts/stake.ts
+++ b/clients/js/src/generated/accounts/stake.ts
@@ -48,7 +48,7 @@ export type Stake = {
   deactivatingAmount: bigint;
   inactiveAmount: bigint;
   authority: Address;
-  validator: Address;
+  validatorVote: Address;
   lastSeenHolderRewards: bigint;
   lastSeenStakeRewards: bigint;
 };
@@ -60,7 +60,7 @@ export type StakeArgs = {
   deactivatingAmount: number | bigint;
   inactiveAmount: number | bigint;
   authority: Address;
-  validator: Address;
+  validatorVote: Address;
   lastSeenHolderRewards: number | bigint;
   lastSeenStakeRewards: number | bigint;
 };
@@ -73,7 +73,7 @@ export function getStakeEncoder(): Encoder<StakeArgs> {
     ['deactivatingAmount', getU64Encoder()],
     ['inactiveAmount', getU64Encoder()],
     ['authority', getAddressEncoder()],
-    ['validator', getAddressEncoder()],
+    ['validatorVote', getAddressEncoder()],
     ['lastSeenHolderRewards', getU64Encoder()],
     ['lastSeenStakeRewards', getU64Encoder()],
   ]);
@@ -87,7 +87,7 @@ export function getStakeDecoder(): Decoder<Stake> {
     ['deactivatingAmount', getU64Decoder()],
     ['inactiveAmount', getU64Decoder()],
     ['authority', getAddressDecoder()],
-    ['validator', getAddressDecoder()],
+    ['validatorVote', getAddressDecoder()],
     ['lastSeenHolderRewards', getU64Decoder()],
     ['lastSeenStakeRewards', getU64Decoder()],
   ]);

--- a/clients/rust/src/generated/accounts/stake.rs
+++ b/clients/rust/src/generated/accounts/stake.rs
@@ -27,7 +27,7 @@ pub struct Stake {
         feature = "serde",
         serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
     )]
-    pub validator: Pubkey,
+    pub validator_vote: Pubkey,
     pub last_seen_holder_rewards: u64,
     pub last_seen_stake_rewards: u64,
 }

--- a/clients/rust/src/pdas.rs
+++ b/clients/rust/src/pdas.rs
@@ -4,11 +4,11 @@ pub fn find_vault_pda(config: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&["token-owner".as_bytes(), config.as_ref()], &crate::ID)
 }
 
-pub fn find_stake_pda(validator: &Pubkey, config: &Pubkey) -> (Pubkey, u8) {
+pub fn find_stake_pda(validator_vote: &Pubkey, config: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[
             "stake::state::stake".as_bytes(),
-            validator.as_ref(),
+            validator_vote.as_ref(),
             config.as_ref(),
         ],
         &crate::ID,

--- a/clients/rust/tests/deactivate_stake.rs
+++ b/clients/rust/tests/deactivate_stake.rs
@@ -53,7 +53,7 @@ async fn deactivate_stake() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &validator, &vote, &config).await;
+    let stake_pda = create_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
     let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
@@ -126,7 +126,7 @@ async fn deactivate_stake_with_active_deactivation() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &validator, &vote, &config).await;
+    let stake_pda = create_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
     let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
@@ -214,7 +214,7 @@ async fn fail_deactivate_stake_with_amount_greater_than_stake_amount() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &validator, &vote, &config).await;
+    let stake_pda = create_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
     let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
@@ -272,7 +272,7 @@ async fn fail_deactivate_stake_with_invalid_authority() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &validator, &vote, &config).await;
+    let stake_pda = create_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
     let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
@@ -332,7 +332,7 @@ async fn fail_deactivate_stake_with_zero_amount() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &validator, &vote, &config).await;
+    let stake_pda = create_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
     let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
@@ -461,7 +461,7 @@ async fn fail_deactivate_stake_with_maximum_deactivation_amount_exceeded() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &validator, &vote, &config).await;
+    let stake_pda = create_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
     let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
@@ -533,7 +533,7 @@ async fn fail_deactivate_stake_with_uninitialized_config_account() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &validator, &vote, &config).await;
+    let stake_pda = create_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
     let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();

--- a/clients/rust/tests/inactivate_stake.rs
+++ b/clients/rust/tests/inactivate_stake.rs
@@ -48,7 +48,7 @@ async fn inactivate_stake() {
     let authority = Keypair::new();
     let vote = create_vote_account(&mut context, &validator, &authority.pubkey()).await;
 
-    let stake_pda = create_stake(&mut context, &validator, &vote, &config).await;
+    let stake_pda = create_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
     let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
@@ -124,7 +124,7 @@ async fn fail_inactivate_stake_with_no_deactivated_amount() {
     let authority = Keypair::new();
     let vote = create_vote_account(&mut context, &validator, &authority.pubkey()).await;
 
-    let stake_pda = create_stake(&mut context, &validator, &vote, &config).await;
+    let stake_pda = create_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
     let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
@@ -181,7 +181,7 @@ async fn fail_inactivate_stake_with_wrong_config() {
     let authority = Keypair::new();
     let vote = create_vote_account(&mut context, &validator, &authority.pubkey()).await;
 
-    let stake_pda = create_stake(&mut context, &validator, &vote, &config).await;
+    let stake_pda = create_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
     let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
@@ -297,7 +297,7 @@ async fn fail_inactivate_stake_with_active_cooldown() {
     let authority = Keypair::new();
     let vote = create_vote_account(&mut context, &validator, &authority.pubkey()).await;
 
-    let stake_pda = create_stake(&mut context, &validator, &vote, &config).await;
+    let stake_pda = create_stake(&mut context, &vote, &config).await;
     let mut account = get_account!(context, stake_pda);
     let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values

--- a/clients/rust/tests/initialize_stake.rs
+++ b/clients/rust/tests/initialize_stake.rs
@@ -30,11 +30,11 @@ async fn initialize_stake_with_validator_vote() {
 
     let config = create_config(&mut context).await;
     let validator = Pubkey::new_unique();
-    let vote = create_vote_account(&mut context, &validator, &validator).await;
+    let validator_vote = create_vote_account(&mut context, &validator, &validator).await;
 
     // When we initialize the stake account.
 
-    let (stake_pda, _) = find_stake_pda(&validator, &config);
+    let (stake_pda, _) = find_stake_pda(&validator_vote, &config);
 
     let transfer_ix = system_instruction::transfer(
         &context.payer.pubkey(),
@@ -50,7 +50,7 @@ async fn initialize_stake_with_validator_vote() {
     let initialize_ix = InitializeStakeBuilder::new()
         .config(config)
         .stake(stake_pda)
-        .validator_vote(vote)
+        .validator_vote(validator_vote)
         .instruction();
 
     let tx = Transaction::new_signed_with_payer(
@@ -68,7 +68,7 @@ async fn initialize_stake_with_validator_vote() {
 
     let account_data = account.data.as_ref();
     let stake_account = Stake::from_bytes(account_data).unwrap();
-    assert_eq!(stake_account.validator, validator);
+    assert_eq!(stake_account.validator, validator_vote);
     assert_eq!(stake_account.authority, validator);
 }
 
@@ -82,11 +82,11 @@ async fn fail_initialize_stake_with_initialized_account() {
 
     let config = create_config(&mut context).await;
     let validator = Pubkey::new_unique();
-    let vote = create_vote_account(&mut context, &validator, &validator).await;
+    let validator_vote = create_vote_account(&mut context, &validator, &validator).await;
 
     // And we initialize the stake account.
 
-    let (stake_pda, _) = find_stake_pda(&validator, &config);
+    let (stake_pda, _) = find_stake_pda(&validator_vote, &config);
 
     let transfer_ix = system_instruction::transfer(
         &context.payer.pubkey(),
@@ -102,7 +102,7 @@ async fn fail_initialize_stake_with_initialized_account() {
     let initialize_ix = InitializeStakeBuilder::new()
         .config(config)
         .stake(stake_pda)
-        .validator_vote(vote)
+        .validator_vote(validator_vote)
         .instruction();
 
     let tx = Transaction::new_signed_with_payer(
@@ -121,7 +121,7 @@ async fn fail_initialize_stake_with_initialized_account() {
     let initialize_ix = InitializeStakeBuilder::new()
         .config(config)
         .stake(stake_pda)
-        .validator_vote(vote)
+        .validator_vote(validator_vote)
         .instruction();
 
     let tx = Transaction::new_signed_with_payer(
@@ -151,7 +151,7 @@ async fn fail_initialize_stake_with_invalid_derivation() {
 
     let config = create_config(&mut context).await;
     let validator = Pubkey::new_unique();
-    let vote = create_vote_account(&mut context, &validator, &validator).await;
+    let validator_vote = create_vote_account(&mut context, &validator, &validator).await;
 
     // When we try initialize the stake account with an invalid derivation.
 
@@ -160,7 +160,7 @@ async fn fail_initialize_stake_with_invalid_derivation() {
     let initialize_ix = InitializeStakeBuilder::new()
         .config(config)
         .stake(stake_pda)
-        .validator_vote(vote)
+        .validator_vote(validator_vote)
         .instruction();
 
     let tx = Transaction::new_signed_with_payer(
@@ -190,7 +190,7 @@ async fn fail_initialize_stake_with_invalid_vote_account() {
 
     let config = create_config(&mut context).await;
     let validator = Pubkey::new_unique();
-    let vote = create_vote_account_with_program_id(
+    let validator_vote = create_vote_account_with_program_id(
         &mut context,
         &validator,
         &validator,
@@ -206,7 +206,7 @@ async fn fail_initialize_stake_with_invalid_vote_account() {
     let initialize_ix = InitializeStakeBuilder::new()
         .config(config)
         .stake(stake_pda)
-        .validator_vote(vote)
+        .validator_vote(validator_vote)
         .instruction();
 
     let tx = Transaction::new_signed_with_payer(
@@ -250,7 +250,7 @@ async fn fail_initialize_stake_with_uninitialized_config_account() {
     );
 
     let validator = Pubkey::new_unique();
-    let vote = create_vote_account_with_program_id(
+    let validator_vote = create_vote_account_with_program_id(
         &mut context,
         &validator,
         &validator,
@@ -265,7 +265,7 @@ async fn fail_initialize_stake_with_uninitialized_config_account() {
     let initialize_ix = InitializeStakeBuilder::new()
         .config(uninitialized_config.pubkey())
         .stake(stake_pda)
-        .validator_vote(vote)
+        .validator_vote(validator_vote)
         .instruction();
 
     let tx = Transaction::new_signed_with_payer(

--- a/clients/rust/tests/initialize_stake.rs
+++ b/clients/rust/tests/initialize_stake.rs
@@ -68,7 +68,7 @@ async fn initialize_stake_with_validator_vote() {
 
     let account_data = account.data.as_ref();
     let stake_account = Stake::from_bytes(account_data).unwrap();
-    assert_eq!(stake_account.validator, validator_vote);
+    assert_eq!(stake_account.validator_vote, validator_vote);
     assert_eq!(stake_account.authority, validator);
 }
 

--- a/clients/rust/tests/set_authority.rs
+++ b/clients/rust/tests/set_authority.rs
@@ -634,11 +634,12 @@ async fn set_authority_on_stake() {
     let config = create_config(&mut context).await;
     let validator = Pubkey::new_unique();
     let withdraw_authority = Keypair::new();
-    let vote = create_vote_account(&mut context, &validator, &withdraw_authority.pubkey()).await;
+    let validator_vote =
+        create_vote_account(&mut context, &validator, &withdraw_authority.pubkey()).await;
 
     // And we initialize the stake account.
 
-    let (stake_pda, _) = find_stake_pda(&validator, &config);
+    let (stake_pda, _) = find_stake_pda(&validator_vote, &config);
 
     let transfer_ix = system_instruction::transfer(
         &context.payer.pubkey(),
@@ -654,7 +655,7 @@ async fn set_authority_on_stake() {
     let initialize_ix = InitializeStakeBuilder::new()
         .config(config)
         .stake(stake_pda)
-        .validator_vote(vote)
+        .validator_vote(validator_vote)
         .instruction();
 
     let tx = Transaction::new_signed_with_payer(
@@ -706,11 +707,12 @@ async fn fail_set_authority_on_stake_with_invalid_authority() {
     let config = create_config(&mut context).await;
     let validator = Pubkey::new_unique();
     let withdraw_authority = Keypair::new();
-    let vote = create_vote_account(&mut context, &validator, &withdraw_authority.pubkey()).await;
+    let validator_vote =
+        create_vote_account(&mut context, &validator, &withdraw_authority.pubkey()).await;
 
     // And we initialize the stake account.
 
-    let (stake_pda, _) = find_stake_pda(&validator, &config);
+    let (stake_pda, _) = find_stake_pda(&validator_vote, &config);
 
     let transfer_ix = system_instruction::transfer(
         &context.payer.pubkey(),
@@ -726,7 +728,7 @@ async fn fail_set_authority_on_stake_with_invalid_authority() {
     let initialize_ix = InitializeStakeBuilder::new()
         .config(config)
         .stake(stake_pda)
-        .validator_vote(vote)
+        .validator_vote(validator_vote)
         .instruction();
 
     let tx = Transaction::new_signed_with_payer(

--- a/clients/rust/tests/setup/stake.rs
+++ b/clients/rust/tests/setup/stake.rs
@@ -4,11 +4,10 @@ use solana_sdk::{pubkey::Pubkey, signer::Signer, system_instruction, transaction
 
 pub async fn create_stake(
     context: &mut ProgramTestContext,
-    validator: &Pubkey,
     vote: &Pubkey,
     config: &Pubkey,
 ) -> Pubkey {
-    let (stake_pda, _) = find_stake_pda(validator, config);
+    let (stake_pda, _) = find_stake_pda(vote, config);
 
     let transfer_ix = system_instruction::transfer(
         &context.payer.pubkey(),

--- a/program/idl.json
+++ b/program/idl.json
@@ -723,7 +723,7 @@
             "type": "publicKey"
           },
           {
-            "name": "validator",
+            "name": "validatorVote",
             "type": "publicKey"
           },
           {

--- a/program/src/processor/deactivate_stake.rs
+++ b/program/src/processor/deactivate_stake.rs
@@ -81,7 +81,8 @@ pub fn process_deactivate_stake(
     );
 
     // validates that the stake account corresponds to the received config account
-    let (derivation, _) = find_stake_pda(&stake.validator, ctx.accounts.config.key, program_id);
+    let (derivation, _) =
+        find_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
 
     require!(
         ctx.accounts.stake.key == &derivation,

--- a/program/src/processor/inactivate_stake.rs
+++ b/program/src/processor/inactivate_stake.rs
@@ -69,7 +69,8 @@ pub fn process_inactivate_stake(
 
     // validates that the stake account corresponds to the received
     // config account
-    let (derivation, _) = find_stake_pda(&stake.validator, ctx.accounts.config.key, program_id);
+    let (derivation, _) =
+        find_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
 
     require!(
         ctx.accounts.stake.key == &derivation,

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -11,11 +11,15 @@ pub fn find_vault_pda(config: &Pubkey, program_id: &Pubkey) -> (Pubkey, u8) {
 }
 
 #[inline(always)]
-pub fn find_stake_pda(validator: &Pubkey, config: &Pubkey, program_id: &Pubkey) -> (Pubkey, u8) {
+pub fn find_stake_pda(
+    validator_vote: &Pubkey,
+    config: &Pubkey,
+    program_id: &Pubkey,
+) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[
             "stake::state::stake".as_bytes(),
-            validator.as_ref(),
+            validator_vote.as_ref(),
             config.as_ref(),
         ],
         program_id,
@@ -24,13 +28,13 @@ pub fn find_stake_pda(validator: &Pubkey, config: &Pubkey, program_id: &Pubkey) 
 
 #[inline(always)]
 pub fn get_stake_pda_signer_seeds<'a>(
-    validator: &'a Pubkey,
+    validator_vote: &'a Pubkey,
     config: &'a Pubkey,
     bump_seed: &'a [u8],
 ) -> [&'a [u8]; 4] {
     [
         "stake::state::stake".as_bytes(),
-        validator.as_ref(),
+        validator_vote.as_ref(),
         config.as_ref(),
         bump_seed,
     ]

--- a/program/src/state/stake.rs
+++ b/program/src/state/stake.rs
@@ -37,7 +37,7 @@ pub struct Stake {
     pub authority: Pubkey,
 
     /// The address of the validator vote account
-    pub validator: Pubkey,
+    pub validator_vote: Pubkey,
 
     /// Stores the "last_seen_holder_rewards" just for this stake account, allowing
     /// stakers to withdraw rewards whenever, just like normal token users
@@ -64,7 +64,7 @@ impl Stake {
             deactivating_amount: u64::default(),
             inactive_amount: u64::default(),
             authority,
-            validator: validator_vote,
+            validator_vote,
             last_seen_holder_rewards: u64::default(),
             last_seen_stake_rewards: u64::default(),
         }

--- a/program/src/state/stake.rs
+++ b/program/src/state/stake.rs
@@ -56,7 +56,7 @@ impl Stake {
         self.discriminator.as_slice() == Stake::SPL_DISCRIMINATOR_SLICE
     }
 
-    pub fn new(authority: Pubkey, validator: Pubkey) -> Self {
+    pub fn new(authority: Pubkey, validator_vote: Pubkey) -> Self {
         Self {
             discriminator: Stake::SPL_DISCRIMINATOR.into(),
             amount: u64::default(),
@@ -64,7 +64,7 @@ impl Stake {
             deactivating_amount: u64::default(),
             inactive_amount: u64::default(),
             authority,
-            validator,
+            validator: validator_vote,
             last_seen_holder_rewards: u64::default(),
             last_seen_stake_rewards: u64::default(),
         }


### PR DESCRIPTION
This PR updates the `Stake` account derivation to use the `validator vote` address instead of the `node id`.