### PR TITLE
Address review comments on `InactivateStake`

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -69,7 +69,7 @@ pub enum StakeError {
     #[error("Active deactivation cooldown")]
     ActiveDeactivationCooldown,
 
-    /// 16 - No deactivated tokens
+    /// 15 - No deactivated tokens
     #[error("No deactivated tokens")]
     NoDeactivatedTokens,
 }

--- a/program/src/processor/inactivate_stake.rs
+++ b/program/src/processor/inactivate_stake.rs
@@ -92,7 +92,7 @@ pub fn process_inactivate_stake(
             inactive_timestamp.saturating_sub(current_timestamp),
         );
 
-        msg!("Deactivating {} token(s)", stake.deactivating_amount);
+        msg!("Inactivating {} token(s)", stake.deactivating_amount);
 
         // moves deactivating amount to inactive
         stake.amount = stake

--- a/program/src/processor/inactivate_stake.rs
+++ b/program/src/processor/inactivate_stake.rs
@@ -94,10 +94,14 @@ pub fn process_inactivate_stake(
         msg!("Deactivating {} token(s)", stake.deactivating_amount);
 
         // moves deactivating amount to inactive
-        stake.amount = stake.amount.saturating_sub(stake.deactivating_amount);
+        stake.amount = stake
+            .amount
+            .checked_sub(stake.deactivating_amount)
+            .ok_or(ProgramError::ArithmeticOverflow)?;
         stake.inactive_amount = stake
             .inactive_amount
-            .saturating_add(stake.deactivating_amount);
+            .checked_add(stake.deactivating_amount)
+            .ok_or(ProgramError::ArithmeticOverflow)?;
 
         // clears the deactivation
         stake.deactivating_amount = 0;

--- a/program/src/processor/inactivate_stake.rs
+++ b/program/src/processor/inactivate_stake.rs
@@ -80,15 +80,16 @@ pub fn process_inactivate_stake(
     // Inactivates the stake if elegible.
 
     if let Some(timestamp) = stake.deactivation_timestamp {
-        let current = Clock::get()?
-            .unix_timestamp
-            .saturating_sub(config.cooldown_time_seconds) as u64;
+        let inactive_timestamp = config
+            .cooldown_time_seconds
+            .saturating_add(timestamp.get() as i64);
+        let current_timestamp = Clock::get()?.unix_timestamp;
 
         require!(
-            current >= timestamp.get(),
+            current_timestamp >= inactive_timestamp,
             StakeError::ActiveDeactivationCooldown,
             "{} second(s) remaining for deactivation",
-            timestamp.get().saturating_sub(current),
+            inactive_timestamp.saturating_sub(current_timestamp),
         );
 
         msg!("Deactivating {} token(s)", stake.deactivating_amount);


### PR DESCRIPTION
This PR addresses review comments on the `InactivateStake`:
* Use `checked_*` operations
* Improve the clarity of the inactive timestamp logic
* Fixes typos on a comment and log message