### PR TITLE
Refactor: rename to `ValidatorStake`

### DIFF
--- a/clients/js/src/generated/accounts/index.ts
+++ b/clients/js/src/generated/accounts/index.ts
@@ -7,4 +7,4 @@
  */
 
 export * from './config';
-export * from './stake';
+export * from './validatorStake';

--- a/clients/js/src/generated/accounts/validatorStake.ts
+++ b/clients/js/src/generated/accounts/validatorStake.ts
@@ -43,7 +43,7 @@ import {
   type NullableU64Args,
 } from '../../hooked';
 
-export type Stake = {
+export type ValidatorStake = {
   discriminator: Array<number>;
   amount: bigint;
   deactivationTimestamp: NullableU64;
@@ -55,7 +55,7 @@ export type Stake = {
   lastSeenStakeRewardsPerToken: bigint;
 };
 
-export type StakeArgs = {
+export type ValidatorStakeArgs = {
   discriminator: Array<number>;
   amount: number | bigint;
   deactivationTimestamp: NullableU64Args;
@@ -67,7 +67,7 @@ export type StakeArgs = {
   lastSeenStakeRewardsPerToken: number | bigint;
 };
 
-export function getStakeEncoder(): Encoder<StakeArgs> {
+export function getValidatorStakeEncoder(): Encoder<ValidatorStakeArgs> {
   return getStructEncoder([
     ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
     ['amount', getU64Encoder()],
@@ -81,7 +81,7 @@ export function getStakeEncoder(): Encoder<StakeArgs> {
   ]);
 }
 
-export function getStakeDecoder(): Decoder<Stake> {
+export function getValidatorStakeDecoder(): Decoder<ValidatorStake> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['amount', getU64Decoder()],
@@ -95,63 +95,74 @@ export function getStakeDecoder(): Decoder<Stake> {
   ]);
 }
 
-export function getStakeCodec(): Codec<StakeArgs, Stake> {
-  return combineCodec(getStakeEncoder(), getStakeDecoder());
+export function getValidatorStakeCodec(): Codec<
+  ValidatorStakeArgs,
+  ValidatorStake
+> {
+  return combineCodec(getValidatorStakeEncoder(), getValidatorStakeDecoder());
 }
 
-export function decodeStake<TAddress extends string = string>(
+export function decodeValidatorStake<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): Account<Stake, TAddress>;
-export function decodeStake<TAddress extends string = string>(
+): Account<ValidatorStake, TAddress>;
+export function decodeValidatorStake<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeAccount<Stake, TAddress>;
-export function decodeStake<TAddress extends string = string>(
+): MaybeAccount<ValidatorStake, TAddress>;
+export function decodeValidatorStake<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): Account<Stake, TAddress> | MaybeAccount<Stake, TAddress> {
+): Account<ValidatorStake, TAddress> | MaybeAccount<ValidatorStake, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getStakeDecoder()
+    getValidatorStakeDecoder()
   );
 }
 
-export async function fetchStake<TAddress extends string = string>(
+export async function fetchValidatorStake<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<Account<Stake, TAddress>> {
-  const maybeAccount = await fetchMaybeStake(rpc, address, config);
+): Promise<Account<ValidatorStake, TAddress>> {
+  const maybeAccount = await fetchMaybeValidatorStake(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
 }
 
-export async function fetchMaybeStake<TAddress extends string = string>(
+export async function fetchMaybeValidatorStake<
+  TAddress extends string = string,
+>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeAccount<Stake, TAddress>> {
+): Promise<MaybeAccount<ValidatorStake, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
-  return decodeStake(maybeAccount);
+  return decodeValidatorStake(maybeAccount);
 }
 
-export async function fetchAllStake(
+export async function fetchAllValidatorStake(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<Account<Stake>[]> {
-  const maybeAccounts = await fetchAllMaybeStake(rpc, addresses, config);
+): Promise<Account<ValidatorStake>[]> {
+  const maybeAccounts = await fetchAllMaybeValidatorStake(
+    rpc,
+    addresses,
+    config
+  );
   assertAccountsExist(maybeAccounts);
   return maybeAccounts;
 }
 
-export async function fetchAllMaybeStake(
+export async function fetchAllMaybeValidatorStake(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeAccount<Stake>[]> {
+): Promise<MaybeAccount<ValidatorStake>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
-  return maybeAccounts.map((maybeAccount) => decodeStake(maybeAccount));
+  return maybeAccounts.map((maybeAccount) =>
+    decodeValidatorStake(maybeAccount)
+  );
 }
 
-export function getStakeSize(): number {
+export function getValidatorStakeSize(): number {
   return 136;
 }

--- a/clients/js/src/generated/programs/paladinStakeProgram.ts
+++ b/clients/js/src/generated/programs/paladinStakeProgram.ts
@@ -27,7 +27,7 @@ export const PALADIN_STAKE_PROGRAM_PROGRAM_ADDRESS =
 
 export enum PaladinStakeProgramAccount {
   Config,
-  Stake,
+  ValidatorStake,
 }
 
 export enum PaladinStakeProgramInstruction {

--- a/clients/rust/src/generated/accounts/mod.rs
+++ b/clients/rust/src/generated/accounts/mod.rs
@@ -6,7 +6,7 @@
 //!
 
 pub(crate) mod r#config;
-pub(crate) mod r#stake;
+pub(crate) mod r#validator_stake;
 
 pub use self::r#config::*;
-pub use self::r#stake::*;
+pub use self::r#validator_stake::*;

--- a/clients/rust/src/generated/accounts/validator_stake.rs
+++ b/clients/rust/src/generated/accounts/validator_stake.rs
@@ -12,7 +12,7 @@ use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Stake {
+pub struct ValidatorStake {
     pub discriminator: [u8; 8],
     pub amount: u64,
     pub deactivation_timestamp: NullableU64,
@@ -32,7 +32,7 @@ pub struct Stake {
     pub last_seen_stake_rewards_per_token: u128,
 }
 
-impl Stake {
+impl ValidatorStake {
     pub const LEN: usize = 136;
 
     #[inline(always)]
@@ -42,7 +42,7 @@ impl Stake {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Stake {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for ValidatorStake {
     type Error = std::io::Error;
 
     fn try_from(
@@ -54,26 +54,26 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Stake {
 }
 
 #[cfg(feature = "anchor")]
-impl anchor_lang::AccountDeserialize for Stake {
+impl anchor_lang::AccountDeserialize for ValidatorStake {
     fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
         Ok(Self::deserialize(buf)?)
     }
 }
 
 #[cfg(feature = "anchor")]
-impl anchor_lang::AccountSerialize for Stake {}
+impl anchor_lang::AccountSerialize for ValidatorStake {}
 
 #[cfg(feature = "anchor")]
-impl anchor_lang::Owner for Stake {
+impl anchor_lang::Owner for ValidatorStake {
     fn owner() -> Pubkey {
         crate::PALADIN_STAKE_PROGRAM_ID
     }
 }
 
 #[cfg(feature = "anchor-idl-build")]
-impl anchor_lang::IdlBuild for Stake {}
+impl anchor_lang::IdlBuild for ValidatorStake {}
 
 #[cfg(feature = "anchor-idl-build")]
-impl anchor_lang::Discriminator for Stake {
+impl anchor_lang::Discriminator for ValidatorStake {
     const DISCRIMINATOR: [u8; 8] = [0; 8];
 }

--- a/clients/rust/src/pdas.rs
+++ b/clients/rust/src/pdas.rs
@@ -7,7 +7,7 @@ pub fn find_vault_pda(config: &Pubkey) -> (Pubkey, u8) {
 pub fn find_stake_pda(validator_vote: &Pubkey, config: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[
-            "stake::state::stake".as_bytes(),
+            "stake::state::validator_stake".as_bytes(),
             validator_vote.as_ref(),
             config.as_ref(),
         ],

--- a/clients/rust/src/pdas.rs
+++ b/clients/rust/src/pdas.rs
@@ -4,7 +4,7 @@ pub fn find_vault_pda(config: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&["token-owner".as_bytes(), config.as_ref()], &crate::ID)
 }
 
-pub fn find_stake_pda(validator_vote: &Pubkey, config: &Pubkey) -> (Pubkey, u8) {
+pub fn find_validator_stake_pda(validator_vote: &Pubkey, config: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[
             "stake::state::validator_stake".as_bytes(),

--- a/clients/rust/tests/deactivate_stake.rs
+++ b/clients/rust/tests/deactivate_stake.rs
@@ -4,14 +4,14 @@ mod setup;
 
 use borsh::BorshSerialize;
 use paladin_stake_program_client::{
-    accounts::{Config, Stake},
+    accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::DeactivateStakeBuilder,
     pdas::find_stake_pda,
 };
 use setup::{
     config::{create_config, create_config_with_args},
-    stake::create_stake,
+    validator_stake::create_validator_stake,
     vote::create_vote_account,
 };
 use solana_program_test::{tokio, ProgramTest};
@@ -57,10 +57,10 @@ async fn deactivate_stake() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 100
     stake_account.amount = 100;
 
@@ -94,7 +94,7 @@ async fn deactivate_stake() {
     // Then the deactivation should be successful.
 
     let account = get_account!(context, stake_pda);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
 
     assert_eq!(stake_account.amount, 100);
     assert_eq!(stake_account.deactivating_amount, 5);
@@ -134,10 +134,10 @@ async fn deactivate_stake_with_active_deactivation() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 100
     stake_account.amount = 100;
 
@@ -169,7 +169,7 @@ async fn deactivate_stake_with_active_deactivation() {
     context.banks_client.process_transaction(tx).await.unwrap();
 
     let account = get_account!(context, stake_pda);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(stake_account.deactivating_amount, 5);
 
     let mut clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
@@ -199,7 +199,7 @@ async fn deactivate_stake_with_active_deactivation() {
     // Then the deactivation should have the updated amount and timestamp.
 
     let account = get_account!(context, stake_pda);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(stake_account.deactivating_amount, 1);
     assert_eq!(
         updated_timestamp as u64,
@@ -226,10 +226,10 @@ async fn fail_deactivate_stake_with_amount_greater_than_stake_amount() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 100
     stake_account.amount = 100;
 
@@ -288,10 +288,10 @@ async fn fail_deactivate_stake_with_invalid_authority() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 100
     stake_account.amount = 100;
 
@@ -352,10 +352,10 @@ async fn deactivate_stake_with_zero_amount() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 100
     stake_account.amount = 100;
 
@@ -389,7 +389,7 @@ async fn deactivate_stake_with_zero_amount() {
     // Then the deactivation should be cancelled.
 
     let account = get_account!(context, stake_pda);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
 
     assert_eq!(stake_account.deactivating_amount, 0);
     assert!(stake_account.deactivation_timestamp.value().is_none())
@@ -424,7 +424,7 @@ async fn fail_deactivate_stake_with_uninitialized_stake_account() {
         &stake_pda,
         &AccountSharedData::from(Account {
             lamports: 100_000_000,
-            data: vec![5; Stake::LEN],
+            data: vec![5; ValidatorStake::LEN],
             owner: paladin_stake_program_client::ID,
             ..Default::default()
         }),
@@ -489,10 +489,10 @@ async fn fail_deactivate_stake_with_maximum_deactivation_amount_exceeded() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 100
     stake_account.amount = 100;
 
@@ -568,10 +568,10 @@ async fn fail_deactivate_stake_with_uninitialized_config_account() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 100
     stake_account.amount = 100;
 

--- a/clients/rust/tests/deactivate_stake.rs
+++ b/clients/rust/tests/deactivate_stake.rs
@@ -7,7 +7,7 @@ use paladin_stake_program_client::{
     accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::DeactivateStakeBuilder,
-    pdas::find_stake_pda,
+    pdas::find_validator_stake_pda,
 };
 use setup::{
     config::{create_config, create_config_with_args},
@@ -418,7 +418,7 @@ async fn fail_deactivate_stake_with_uninitialized_stake_account() {
 
     // And an uninitialized stake account.
 
-    let (stake_pda, _) = find_stake_pda(&validator, &config);
+    let (stake_pda, _) = find_validator_stake_pda(&validator, &config);
 
     context.set_account(
         &stake_pda,

--- a/clients/rust/tests/harvest_holder_rewards.rs
+++ b/clients/rust/tests/harvest_holder_rewards.rs
@@ -8,7 +8,7 @@ use paladin_stake_program_client::{
     accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::HarvestHolderRewardsBuilder,
-    pdas::{find_stake_pda, find_vault_pda},
+    pdas::{find_validator_stake_pda, find_vault_pda},
 };
 use setup::{
     config::ConfigManager,
@@ -624,7 +624,7 @@ async fn fail_harvest_holder_rewards_with_uninitialized_stake() {
     // And an uninitialized stake account.
 
     let validator_vote = Pubkey::new_unique();
-    let (stake, _) = find_stake_pda(&validator_vote, &config_manager.config);
+    let (stake, _) = find_validator_stake_pda(&validator_vote, &config_manager.config);
 
     context.set_account(
         &stake,

--- a/clients/rust/tests/harvest_holder_rewards.rs
+++ b/clients/rust/tests/harvest_holder_rewards.rs
@@ -5,7 +5,7 @@ mod setup;
 use borsh::BorshSerialize;
 use paladin_rewards_program_client::accounts::HolderRewards;
 use paladin_stake_program_client::{
-    accounts::{Config, Stake},
+    accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::HarvestHolderRewardsBuilder,
     pdas::{find_stake_pda, find_vault_pda},
@@ -13,7 +13,7 @@ use paladin_stake_program_client::{
 use setup::{
     config::ConfigManager,
     rewards::{create_holder_rewards, create_holder_rewards_pool},
-    stake::StakeManager,
+    validator_stake::ValidatorStakeManager,
 };
 use solana_program_test::{tokio, ProgramTest};
 use solana_sdk::{
@@ -58,10 +58,10 @@ async fn harvest_holder_rewards() {
 
     // And a stake account wiht a 50 staked amount.
 
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -141,7 +141,7 @@ async fn harvest_holder_rewards() {
     // And the stake account last seen holder rewards per token is update.
 
     let account = get_account!(context, stake_manager.stake);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         stake_account.last_seen_holder_rewards_per_token,
         40_000_000 * 1_000_000_000
@@ -192,7 +192,7 @@ async fn harvest_holder_rewards_with_no_rewards_available() {
 
     // And a stake account wiht a no staked amount.
 
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we initialize the holder rewards accounts.
 
@@ -256,7 +256,7 @@ async fn harvest_holder_rewards_with_no_rewards_available() {
     // And the stake account last seen holder rewards per token is not updated.
 
     let account = get_account!(context, stake_manager.stake);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(stake_account.last_seen_holder_rewards_per_token, 0);
 }
 
@@ -294,10 +294,10 @@ async fn harvest_holder_rewards_after_harvesting() {
 
     // And a stake account wiht a 50 staked amount.
 
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -400,7 +400,7 @@ async fn harvest_holder_rewards_after_harvesting() {
     // And the stake account last seen holder rewards per token is update.
 
     let account = get_account!(context, stake_manager.stake);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         stake_account.last_seen_holder_rewards_per_token,
         40_000_000 * 1_000_000_000
@@ -440,10 +440,10 @@ async fn fail_harvest_holder_rewards_with_wrong_authority() {
 
     // And a stake account wiht a 50 staked amount.
 
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -526,7 +526,7 @@ async fn fail_harvest_holder_rewards_with_uninitialized_config() {
     // Given a config account (which will be uninitialized) and a stake account.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we initialize the holder rewards accounts.
 
@@ -630,7 +630,7 @@ async fn fail_harvest_holder_rewards_with_uninitialized_stake() {
         &stake,
         &AccountSharedData::from(Account {
             lamports: 100_000_000,
-            data: vec![5; Stake::LEN],
+            data: vec![5; ValidatorStake::LEN],
             owner: paladin_stake_program_client::ID,
             ..Default::default()
         }),
@@ -720,10 +720,10 @@ async fn fail_harvest_holder_rewards_with_wrong_config() {
 
     // And a stake account wiht a 50 staked amount.
 
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -825,10 +825,10 @@ async fn fail_harvest_holder_rewards_with_invalid_destination() {
 
     // And a stake account wiht a 50 staked amount.
 
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 

--- a/clients/rust/tests/harvest_stake_rewards.rs
+++ b/clients/rust/tests/harvest_stake_rewards.rs
@@ -7,7 +7,7 @@ use paladin_stake_program_client::{
     accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::HarvestStakeRewardsBuilder,
-    pdas::find_stake_pda,
+    pdas::find_validator_stake_pda,
 };
 use setup::{
     config::create_config, validator_stake::create_validator_stake, vote::create_vote_account,
@@ -469,7 +469,7 @@ async fn fail_harvest_stake_rewards_with_uninitialized_stake_account() {
 
     // And an uninitialized stake account.
 
-    let (stake_pda, _) = find_stake_pda(&validator, &config);
+    let (stake_pda, _) = find_validator_stake_pda(&validator, &config);
 
     context.set_account(
         &stake_pda,

--- a/clients/rust/tests/harvest_stake_rewards.rs
+++ b/clients/rust/tests/harvest_stake_rewards.rs
@@ -4,12 +4,14 @@ mod setup;
 
 use borsh::BorshSerialize;
 use paladin_stake_program_client::{
-    accounts::{Config, Stake},
+    accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::HarvestStakeRewardsBuilder,
     pdas::find_stake_pda,
 };
-use setup::{config::create_config, stake::create_stake, vote::create_vote_account};
+use setup::{
+    config::create_config, validator_stake::create_validator_stake, vote::create_vote_account,
+};
 use solana_program_test::{tokio, ProgramTest};
 use solana_sdk::{
     account::{Account, AccountSharedData},
@@ -65,10 +67,10 @@ async fn harvest_stake_rewards() {
 
     // And a stake account wiht a 50 staked amount.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -109,7 +111,7 @@ async fn harvest_stake_rewards() {
 
     // And the stake account has the updated last seen stake rewards per token.
     let account = get_account!(context, stake_pda);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         stake_account.last_seen_stake_rewards_per_token,
         40_000_000 * 1_000_000_000 // 0.04 * 1e9
@@ -144,10 +146,10 @@ async fn harvest_stake_rewards_with_no_rewards_available() {
 
     // And a stake account wiht a 50 staked amount.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -211,10 +213,10 @@ async fn harvest_stake_rewards_after_harvesting() {
 
     // And a stake account wiht a 50 staked amount.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -329,10 +331,10 @@ async fn fail_harvest_stake_rewards_with_wrong_authority() {
 
     // And a stake account wiht a 50 staked amount.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -387,10 +389,10 @@ async fn fail_harvest_stake_rewards_with_uninitialized_config_account() {
 
     // And a stake account.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -473,7 +475,7 @@ async fn fail_harvest_stake_rewards_with_uninitialized_stake_account() {
         &stake_pda,
         &AccountSharedData::from(Account {
             lamports: 100_000_000,
-            data: vec![5; Stake::LEN],
+            data: vec![5; ValidatorStake::LEN],
             owner: paladin_stake_program_client::ID,
             ..Default::default()
         }),
@@ -539,10 +541,10 @@ async fn fail_harvest_stake_rewards_with_wrong_config_account() {
 
     // And a stake account wiht a 50 staked amount.
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 

--- a/clients/rust/tests/inactivate_stake.rs
+++ b/clients/rust/tests/inactivate_stake.rs
@@ -7,7 +7,7 @@ use paladin_stake_program_client::{
     accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::InactivateStakeBuilder,
-    pdas::find_stake_pda,
+    pdas::find_validator_stake_pda,
     NullableU64,
 };
 use setup::{
@@ -249,7 +249,7 @@ async fn fail_inactivate_stake_with_uninitialized_stake_account() {
 
     // And an uninitialized stake account.
 
-    let (stake_pda, _) = find_stake_pda(&validator, &config);
+    let (stake_pda, _) = find_validator_stake_pda(&validator, &config);
 
     context.set_account(
         &stake_pda,

--- a/clients/rust/tests/inactivate_stake.rs
+++ b/clients/rust/tests/inactivate_stake.rs
@@ -4,7 +4,7 @@ mod setup;
 
 use borsh::BorshSerialize;
 use paladin_stake_program_client::{
-    accounts::{Config, Stake},
+    accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::InactivateStakeBuilder,
     pdas::find_stake_pda,
@@ -12,7 +12,7 @@ use paladin_stake_program_client::{
 };
 use setup::{
     config::{create_config, create_config_with_args},
-    stake::create_stake,
+    validator_stake::create_validator_stake,
     vote::create_vote_account,
 };
 use solana_program_test::{tokio, ProgramTest};
@@ -52,10 +52,10 @@ async fn inactivate_stake() {
     let authority = Keypair::new();
     let vote = create_vote_account(&mut context, &validator, &authority.pubkey()).await;
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 100;
     stake_account.deactivating_amount = 50;
@@ -90,7 +90,7 @@ async fn inactivate_stake() {
     // Then the inactivation should be successful.
 
     let account = get_account!(context, stake_pda);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
 
     assert_eq!(stake_account.amount, 50);
     assert_eq!(stake_account.deactivating_amount, 0);
@@ -132,10 +132,10 @@ async fn fail_inactivate_stake_with_no_deactivated_amount() {
     let authority = Keypair::new();
     let vote = create_vote_account(&mut context, &validator, &authority.pubkey()).await;
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 100;
     // "manually" update the stake account data
@@ -193,10 +193,10 @@ async fn fail_inactivate_stake_with_wrong_config() {
     let authority = Keypair::new();
     let vote = create_vote_account(&mut context, &validator, &authority.pubkey()).await;
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
 
     let mut account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 100;
     stake_account.deactivating_amount = 50;
@@ -255,7 +255,7 @@ async fn fail_inactivate_stake_with_uninitialized_stake_account() {
         &stake_pda,
         &AccountSharedData::from(Account {
             lamports: 100_000_000,
-            data: vec![5; Stake::LEN],
+            data: vec![5; ValidatorStake::LEN],
             owner: paladin_stake_program_client::ID,
             ..Default::default()
         }),
@@ -317,9 +317,9 @@ async fn fail_inactivate_stake_with_active_cooldown() {
     let authority = Keypair::new();
     let vote = create_vote_account(&mut context, &validator, &authority.pubkey()).await;
 
-    let stake_pda = create_stake(&mut context, &vote, &config).await;
+    let stake_pda = create_validator_stake(&mut context, &vote, &config).await;
     let mut account = get_account!(context, stake_pda);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 100;
     stake_account.deactivating_amount = 50;

--- a/clients/rust/tests/initialize_stake.rs
+++ b/clients/rust/tests/initialize_stake.rs
@@ -3,7 +3,7 @@
 mod setup;
 
 use paladin_stake_program_client::{
-    accounts::{Config, Stake},
+    accounts::{Config, ValidatorStake},
     instructions::InitializeStakeBuilder,
     pdas::find_stake_pda,
 };
@@ -48,7 +48,7 @@ async fn initialize_stake_with_validator_vote() {
             .get_rent()
             .await
             .unwrap()
-            .minimum_balance(Stake::LEN),
+            .minimum_balance(ValidatorStake::LEN),
     );
 
     let initialize_ix = InitializeStakeBuilder::new()
@@ -68,10 +68,10 @@ async fn initialize_stake_with_validator_vote() {
     // Then an account was created with the correct data.
 
     let account = get_account!(context, stake_pda);
-    assert_eq!(account.data.len(), Stake::LEN);
+    assert_eq!(account.data.len(), ValidatorStake::LEN);
 
     let account_data = account.data.as_ref();
-    let stake_account = Stake::from_bytes(account_data).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account_data).unwrap();
     assert_eq!(stake_account.validator_vote, validator_vote);
     assert_eq!(stake_account.authority, validator);
 }
@@ -104,7 +104,7 @@ async fn fail_initialize_stake_with_initialized_account() {
             .get_rent()
             .await
             .unwrap()
-            .minimum_balance(Stake::LEN),
+            .minimum_balance(ValidatorStake::LEN),
     );
 
     let initialize_ix = InitializeStakeBuilder::new()
@@ -122,7 +122,7 @@ async fn fail_initialize_stake_with_initialized_account() {
     context.banks_client.process_transaction(tx).await.unwrap();
 
     let account = get_account!(context, stake_pda);
-    assert_eq!(account.data.len(), Stake::LEN);
+    assert_eq!(account.data.len(), ValidatorStake::LEN);
 
     // When we try to initialize the stake account again.
 

--- a/clients/rust/tests/initialize_stake.rs
+++ b/clients/rust/tests/initialize_stake.rs
@@ -5,7 +5,7 @@ mod setup;
 use paladin_stake_program_client::{
     accounts::{Config, ValidatorStake},
     instructions::InitializeStakeBuilder,
-    pdas::find_stake_pda,
+    pdas::find_validator_stake_pda,
 };
 use setup::{
     config::create_config,
@@ -38,7 +38,7 @@ async fn initialize_stake_with_validator_vote() {
 
     // When we initialize the stake account.
 
-    let (stake_pda, _) = find_stake_pda(&validator_vote, &config);
+    let (stake_pda, _) = find_validator_stake_pda(&validator_vote, &config);
 
     let transfer_ix = system_instruction::transfer(
         &context.payer.pubkey(),
@@ -94,7 +94,7 @@ async fn fail_initialize_stake_with_initialized_account() {
 
     // And we initialize the stake account.
 
-    let (stake_pda, _) = find_stake_pda(&validator_vote, &config);
+    let (stake_pda, _) = find_validator_stake_pda(&validator_vote, &config);
 
     let transfer_ix = system_instruction::transfer(
         &context.payer.pubkey(),
@@ -167,7 +167,7 @@ async fn fail_initialize_stake_with_invalid_derivation() {
 
     // When we try initialize the stake account with an invalid derivation.
 
-    let (stake_pda, _) = find_stake_pda(&Pubkey::new_unique(), &config);
+    let (stake_pda, _) = find_validator_stake_pda(&Pubkey::new_unique(), &config);
 
     let initialize_ix = InitializeStakeBuilder::new()
         .config(config)
@@ -217,7 +217,7 @@ async fn fail_initialize_stake_with_invalid_vote_account() {
     // When we try initialize the stake account with an invalid validator vote account
     // (the validator vote account is owned by system program).
 
-    let (stake_pda, _) = find_stake_pda(&Pubkey::new_unique(), &config);
+    let (stake_pda, _) = find_validator_stake_pda(&Pubkey::new_unique(), &config);
 
     let initialize_ix = InitializeStakeBuilder::new()
         .config(config)
@@ -280,7 +280,8 @@ async fn fail_initialize_stake_with_uninitialized_config_account() {
 
     // When we try initialize the stake account with an invalid derivation.
 
-    let (stake_pda, _) = find_stake_pda(&Pubkey::new_unique(), &uninitialized_config.pubkey());
+    let (stake_pda, _) =
+        find_validator_stake_pda(&Pubkey::new_unique(), &uninitialized_config.pubkey());
 
     let initialize_ix = InitializeStakeBuilder::new()
         .config(uninitialized_config.pubkey())

--- a/clients/rust/tests/set_authority.rs
+++ b/clients/rust/tests/set_authority.rs
@@ -6,7 +6,7 @@ use paladin_stake_program_client::{
     accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::{InitializeConfigBuilder, InitializeStakeBuilder, SetAuthorityBuilder},
-    pdas::{find_stake_pda, find_vault_pda},
+    pdas::{find_validator_stake_pda, find_vault_pda},
     types::AuthorityType,
 };
 use setup::{
@@ -667,7 +667,7 @@ async fn set_authority_on_stake() {
 
     // And we initialize the stake account.
 
-    let (stake_pda, _) = find_stake_pda(&validator_vote, &config);
+    let (stake_pda, _) = find_validator_stake_pda(&validator_vote, &config);
 
     let transfer_ix = system_instruction::transfer(
         &context.payer.pubkey(),
@@ -744,7 +744,7 @@ async fn fail_set_authority_on_stake_with_invalid_authority() {
 
     // And we initialize the stake account.
 
-    let (stake_pda, _) = find_stake_pda(&validator_vote, &config);
+    let (stake_pda, _) = find_validator_stake_pda(&validator_vote, &config);
 
     let transfer_ix = system_instruction::transfer(
         &context.payer.pubkey(),

--- a/clients/rust/tests/set_authority.rs
+++ b/clients/rust/tests/set_authority.rs
@@ -3,7 +3,7 @@
 mod setup;
 
 use paladin_stake_program_client::{
-    accounts::{Config, Stake},
+    accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::{InitializeConfigBuilder, InitializeStakeBuilder, SetAuthorityBuilder},
     pdas::{find_stake_pda, find_vault_pda},
@@ -677,7 +677,7 @@ async fn set_authority_on_stake() {
             .get_rent()
             .await
             .unwrap()
-            .minimum_balance(Stake::LEN),
+            .minimum_balance(ValidatorStake::LEN),
     );
 
     let initialize_ix = InitializeStakeBuilder::new()
@@ -695,7 +695,7 @@ async fn set_authority_on_stake() {
     context.banks_client.process_transaction(tx).await.unwrap();
 
     let account = get_account!(context, stake_pda);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(stake_account.authority, withdraw_authority.pubkey());
 
     // When we set a new authority on the stake account.
@@ -720,7 +720,7 @@ async fn set_authority_on_stake() {
     // Then the stake authority is updated.
 
     let account = get_account!(context, stake_pda);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(stake_account.authority, new_authority);
 }
 
@@ -754,7 +754,7 @@ async fn fail_set_authority_on_stake_with_invalid_authority() {
             .get_rent()
             .await
             .unwrap()
-            .minimum_balance(Stake::LEN),
+            .minimum_balance(ValidatorStake::LEN),
     );
 
     let initialize_ix = InitializeStakeBuilder::new()
@@ -772,7 +772,7 @@ async fn fail_set_authority_on_stake_with_invalid_authority() {
     context.banks_client.process_transaction(tx).await.unwrap();
 
     let account = get_account!(context, stake_pda);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(stake_account.authority, withdraw_authority.pubkey());
 
     // When we try to set a new authority on the stake account with an invalid authority.

--- a/clients/rust/tests/setup/mod.rs
+++ b/clients/rust/tests/setup/mod.rs
@@ -9,8 +9,8 @@ use spl_transfer_hook_interface::{
 
 pub mod config;
 pub mod rewards;
-pub mod stake;
 pub mod token;
+pub mod validator_stake;
 pub mod vote;
 
 /// Scaling factor for rewards per token (1e9).

--- a/clients/rust/tests/setup/validator_stake.rs
+++ b/clients/rust/tests/setup/validator_stake.rs
@@ -1,5 +1,5 @@
 use paladin_stake_program_client::{
-    accounts::Stake, instructions::InitializeStakeBuilder, pdas::find_stake_pda,
+    accounts::ValidatorStake, instructions::InitializeStakeBuilder, pdas::find_stake_pda,
 };
 use solana_program_test::ProgramTestContext;
 use solana_sdk::{
@@ -9,7 +9,7 @@ use solana_sdk::{
 
 use super::vote::create_vote_account;
 
-pub struct StakeManager {
+pub struct ValidatorStakeManager {
     // Stake account.
     pub stake: Pubkey,
     // Stake authority.
@@ -20,7 +20,7 @@ pub struct StakeManager {
     pub vote: Pubkey,
 }
 
-impl StakeManager {
+impl ValidatorStakeManager {
     pub async fn new(context: &mut ProgramTestContext, config: &Pubkey) -> Self {
         let authority = Keypair::new();
         let validator = Pubkey::new_unique();
@@ -31,7 +31,7 @@ impl StakeManager {
 
         // And a stake account.
 
-        let stake = create_stake(context, &vote, config).await;
+        let stake = create_validator_stake(context, &vote, config).await;
 
         let transfer_ix = system_instruction::transfer(
             &context.payer.pubkey(),
@@ -41,7 +41,7 @@ impl StakeManager {
                 .get_rent()
                 .await
                 .unwrap()
-                .minimum_balance(Stake::LEN),
+                .minimum_balance(ValidatorStake::LEN),
         );
 
         let initialize_ix = InitializeStakeBuilder::new()
@@ -73,7 +73,7 @@ impl StakeManager {
     }
 }
 
-pub async fn create_stake(
+pub async fn create_validator_stake(
     context: &mut ProgramTestContext,
     vote: &Pubkey,
     config: &Pubkey,
@@ -88,7 +88,7 @@ pub async fn create_stake(
             .get_rent()
             .await
             .unwrap()
-            .minimum_balance(Stake::LEN),
+            .minimum_balance(ValidatorStake::LEN),
     );
 
     let initialize_ix = InitializeStakeBuilder::new()

--- a/clients/rust/tests/setup/validator_stake.rs
+++ b/clients/rust/tests/setup/validator_stake.rs
@@ -1,5 +1,5 @@
 use paladin_stake_program_client::{
-    accounts::ValidatorStake, instructions::InitializeStakeBuilder, pdas::find_stake_pda,
+    accounts::ValidatorStake, instructions::InitializeStakeBuilder, pdas::find_validator_stake_pda,
 };
 use solana_program_test::ProgramTestContext;
 use solana_sdk::{
@@ -78,7 +78,7 @@ pub async fn create_validator_stake(
     vote: &Pubkey,
     config: &Pubkey,
 ) -> Pubkey {
-    let (stake_pda, _) = find_stake_pda(vote, config);
+    let (stake_pda, _) = find_validator_stake_pda(vote, config);
 
     let transfer_ix = system_instruction::transfer(
         &context.payer.pubkey(),

--- a/clients/rust/tests/slash.rs
+++ b/clients/rust/tests/slash.rs
@@ -7,7 +7,7 @@ use paladin_stake_program_client::{
     accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::SlashBuilder,
-    pdas::{find_stake_pda, find_vault_pda},
+    pdas::{find_validator_stake_pda, find_vault_pda},
     NullableU64,
 };
 use setup::{
@@ -465,7 +465,7 @@ async fn fail_slash_with_uninitialized_stake_account() {
     // And an uninitialized stake account.
 
     let validator_vote = Pubkey::new_unique();
-    let (stake, _) = find_stake_pda(&validator_vote, &config_manager.config);
+    let (stake, _) = find_validator_stake_pda(&validator_vote, &config_manager.config);
 
     context.set_account(
         &stake,

--- a/clients/rust/tests/slash.rs
+++ b/clients/rust/tests/slash.rs
@@ -4,7 +4,7 @@ mod setup;
 
 use borsh::BorshSerialize;
 use paladin_stake_program_client::{
-    accounts::{Config, Stake},
+    accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::SlashBuilder,
     pdas::{find_stake_pda, find_vault_pda},
@@ -12,8 +12,8 @@ use paladin_stake_program_client::{
 };
 use setup::{
     config::ConfigManager,
-    stake::StakeManager,
     token::{create_token_account, mint_to, TOKEN_ACCOUNT_EXTENSIONS},
+    validator_stake::ValidatorStakeManager,
 };
 use solana_program_test::{tokio, ProgramTest};
 use solana_sdk::{
@@ -39,7 +39,7 @@ async fn slash() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set 100 tokens to the vault account.
 
@@ -64,7 +64,7 @@ async fn slash() {
     // And we set 50 tokens to the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -108,7 +108,7 @@ async fn slash() {
     // And the slashed stake account has no tokens.
 
     let account = get_account!(context, stake_manager.stake);
-    let stake = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(stake.amount, 0);
 }
 
@@ -125,7 +125,7 @@ async fn fail_slash_with_zero_amount() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set 100 tokens to the vault account.
 
@@ -150,7 +150,7 @@ async fn fail_slash_with_zero_amount() {
     // And we set 50 tokens to the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -201,7 +201,7 @@ async fn slash_with_no_staked_amount() {
     // staked).
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set 100 tokens to the vault account.
 
@@ -265,7 +265,7 @@ async fn fail_slash_with_invalid_slash_authority() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set 100 tokens to the vault account.
 
@@ -290,7 +290,7 @@ async fn fail_slash_with_invalid_slash_authority() {
     // And we set 50 tokens to the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -342,7 +342,7 @@ async fn fail_slash_with_incorrect_vault_account() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set 100 tokens to the vault account.
 
@@ -367,7 +367,7 @@ async fn fail_slash_with_incorrect_vault_account() {
     // And we set 50 tokens to the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -471,7 +471,7 @@ async fn fail_slash_with_uninitialized_stake_account() {
         &stake,
         &AccountSharedData::from(Account {
             lamports: 100_000_000,
-            data: vec![5; Stake::LEN],
+            data: vec![5; ValidatorStake::LEN],
             owner: paladin_stake_program_client::ID,
             ..Default::default()
         }),
@@ -520,7 +520,7 @@ async fn fail_slash_with_uninitialized_config_account() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set 100 tokens to the vault account.
 
@@ -545,7 +545,7 @@ async fn fail_slash_with_uninitialized_config_account() {
     // And we set 50 tokens to the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -607,7 +607,7 @@ async fn fail_slash_with_wrong_config_account() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set 100 tokens to the vault account.
 
@@ -632,7 +632,7 @@ async fn fail_slash_with_wrong_config_account() {
     // And we set 100 tokens to the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 50
     stake_account.amount = 50;
 
@@ -686,7 +686,7 @@ async fn fail_slash_with_insufficient_total_amount_delegated() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set 50 tokens to the vault account.
 
@@ -711,7 +711,7 @@ async fn fail_slash_with_insufficient_total_amount_delegated() {
     // And we set 100 tokens to the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 100
     stake_account.amount = 100;
 
@@ -761,7 +761,7 @@ async fn slash_updating_deactivating_amount() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set 75 tokens to the vault account.
 
@@ -787,7 +787,7 @@ async fn slash_updating_deactivating_amount() {
     // 25 deactivating).
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 75, inactive amount to 25 and
     // deactivating amount to 25
     stake_account.amount = 75;
@@ -841,7 +841,7 @@ async fn slash_updating_deactivating_amount() {
     // And the slashed stake account has no active/deactivating tokens.
 
     let account = get_account!(context, stake_manager.stake);
-    let stake = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(stake.amount, 0);
     assert_eq!(stake.deactivating_amount, 0);
     assert!(stake.deactivation_timestamp.value().is_none());
@@ -861,7 +861,7 @@ async fn slash_with_insufficient_stake_amount() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set 100 tokens to the vault account.
 
@@ -886,7 +886,7 @@ async fn slash_with_insufficient_stake_amount() {
     // And we set 500 active tokens and 100 inactive.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the amount to 500, inactive amount to 100
     stake_account.amount = 500;
     stake_account.inactive_amount = 100;
@@ -931,7 +931,7 @@ async fn slash_with_insufficient_stake_amount() {
     // And the slashed stake account has no active tokens (100 inactive).
 
     let account = get_account!(context, stake_manager.stake);
-    let stake = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(stake.amount, 0);
     assert_eq!(stake.deactivating_amount, 0);
     assert_eq!(stake.inactive_amount, 100);

--- a/clients/rust/tests/stake_tokens.rs
+++ b/clients/rust/tests/stake_tokens.rs
@@ -6,7 +6,7 @@ use paladin_stake_program_client::{
     accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::StakeTokensBuilder,
-    pdas::find_stake_pda,
+    pdas::find_validator_stake_pda,
 };
 use setup::{
     add_extra_account_metas_for_transfer,
@@ -469,7 +469,7 @@ async fn fail_stake_tokens_with_uninitialized_stake_account() {
         &config_manager.authority.pubkey(),
     )
     .await;
-    let (stake_pda, _) = find_stake_pda(&validator_vote, &config_manager.config);
+    let (stake_pda, _) = find_validator_stake_pda(&validator_vote, &config_manager.config);
 
     context.set_account(
         &stake_pda,

--- a/clients/rust/tests/stake_tokens.rs
+++ b/clients/rust/tests/stake_tokens.rs
@@ -3,7 +3,7 @@
 mod setup;
 
 use paladin_stake_program_client::{
-    accounts::{Config, Stake},
+    accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::StakeTokensBuilder,
     pdas::find_stake_pda,
@@ -12,8 +12,8 @@ use setup::{
     add_extra_account_metas_for_transfer,
     config::ConfigManager,
     rewards::{create_holder_rewards, RewardsManager},
-    stake::StakeManager,
     token::{create_token_account, mint_to, TOKEN_ACCOUNT_EXTENSIONS},
+    validator_stake::ValidatorStakeManager,
     vote::create_vote_account,
 };
 use solana_program_test::{tokio, ProgramTest};
@@ -43,7 +43,7 @@ async fn stake_tokens() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we initialize the holder rewards accounts and mint 100 tokens.
 
@@ -111,7 +111,7 @@ async fn stake_tokens() {
     // Then the tokens are staked.
 
     let account = get_account!(context, stake_manager.stake);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(stake_account.amount, 50);
 
     // And the vault account has 50 tokens.
@@ -144,7 +144,7 @@ async fn fail_stake_tokens_with_wrong_vault_account() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we initialize the holder rewards accounts and mint 100 tokens.
 
@@ -246,7 +246,7 @@ async fn fail_stake_tokens_with_wrong_config_account() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we initialize the holder rewards accounts and mint 100 tokens.
 
@@ -339,7 +339,7 @@ async fn fail_stake_tokens_with_zero_amount() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we initialize the holder rewards accounts and mint 100 tokens.
 
@@ -475,7 +475,7 @@ async fn fail_stake_tokens_with_uninitialized_stake_account() {
         &stake_pda,
         &AccountSharedData::from(solana_sdk::account::Account {
             lamports: 100_000_000,
-            data: vec![5; Stake::LEN],
+            data: vec![5; ValidatorStake::LEN],
             owner: paladin_stake_program_client::ID,
             ..Default::default()
         }),

--- a/clients/rust/tests/withdraw_inactive_stake.rs
+++ b/clients/rust/tests/withdraw_inactive_stake.rs
@@ -4,7 +4,7 @@ mod setup;
 
 use borsh::BorshSerialize;
 use paladin_stake_program_client::{
-    accounts::{Config, Stake},
+    accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::WithdrawInactiveStakeBuilder,
     pdas::{find_stake_pda, find_vault_pda},
@@ -13,10 +13,10 @@ use setup::{
     add_extra_account_metas_for_transfer,
     config::ConfigManager,
     rewards::{create_holder_rewards, RewardsManager},
-    stake::StakeManager,
     token::{
         create_associated_token_account, create_token_account, mint_to, TOKEN_ACCOUNT_EXTENSIONS,
     },
+    validator_stake::ValidatorStakeManager,
 };
 use solana_program_test::{tokio, ProgramTest};
 use solana_sdk::{
@@ -45,7 +45,7 @@ async fn withdraw_inactive_stake() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set total amount delegated = 50 on the config account.
 
@@ -70,7 +70,7 @@ async fn withdraw_inactive_stake() {
     // And we set the amount = 50 and inactive_account = 50 on the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 50;
     stake_account.inactive_amount = 50;
@@ -160,7 +160,7 @@ async fn withdraw_inactive_stake() {
     // And the inactive amount on the stake account should be updated.
 
     let account = get_account!(context, stake_manager.stake);
-    let stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(stake_account.inactive_amount, 0);
 
     // And the vault account should have 50 tokens (decreased from 100).
@@ -188,7 +188,7 @@ async fn fail_withdraw_inactive_stake_without_inactive_stake() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set total amount delegated = 100 on the config account.
 
@@ -213,7 +213,7 @@ async fn fail_withdraw_inactive_stake_without_inactive_stake() {
     // And we set the amount = 100 and no inactive stake.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 100;
     // "manually" update the stake account data
@@ -311,7 +311,7 @@ async fn fail_withdraw_inactive_stake_with_invalid_stake_authority() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set total amount delegated = 100 on the config account.
 
@@ -356,7 +356,7 @@ async fn fail_withdraw_inactive_stake_with_invalid_stake_authority() {
     // And we set the amount = 50 and inactive_account = 50 on the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 50;
     stake_account.inactive_amount = 50;
@@ -487,7 +487,7 @@ async fn fail_withdraw_inactive_stake_with_uninitialized_stake_account() {
         &stake,
         &AccountSharedData::from(Account {
             lamports: 100_000_000,
-            data: vec![5; Stake::LEN],
+            data: vec![5; ValidatorStake::LEN],
             owner: paladin_stake_program_client::ID,
             ..Default::default()
         }),
@@ -584,7 +584,7 @@ async fn fail_withdraw_inactive_stake_with_uninitialized_config_account() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set total amount delegated = 100 on the config account.
 
@@ -609,7 +609,7 @@ async fn fail_withdraw_inactive_stake_with_uninitialized_config_account() {
     // And we set the amount = 50 and inactive_account = 50 on the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 50;
     stake_account.inactive_amount = 50;
@@ -720,7 +720,7 @@ async fn fail_withdraw_inactive_stake_with_wrong_config_account() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set total amount delegated = 100 on the config account.
 
@@ -745,7 +745,7 @@ async fn fail_withdraw_inactive_stake_with_wrong_config_account() {
     // And we set the amount = 50 and inactive_account = 50 on the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 50;
     stake_account.inactive_amount = 50;
@@ -848,7 +848,7 @@ async fn fail_withdraw_inactive_stake_with_wrong_mint() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set total amount delegated = 100 on the config account.
 
@@ -873,7 +873,7 @@ async fn fail_withdraw_inactive_stake_with_wrong_mint() {
     // And we set the amount = 50 and inactive_account = 50 on the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 50;
     stake_account.inactive_amount = 50;
@@ -983,7 +983,7 @@ async fn fail_withdraw_inactive_stake_with_wrong_vault_account() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set total amount delegated = 100 on the config account.
 
@@ -1008,7 +1008,7 @@ async fn fail_withdraw_inactive_stake_with_wrong_vault_account() {
     // And we set the amount = 50 and inactive_account = 50 on the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 50;
     stake_account.inactive_amount = 50;
@@ -1120,7 +1120,7 @@ async fn fail_withdraw_inactive_stake_with_vault_as_destination() {
     // Given a config and stake accounts.
 
     let config_manager = ConfigManager::new(&mut context).await;
-    let stake_manager = StakeManager::new(&mut context, &config_manager.config).await;
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
 
     // And we set total amount delegated = 100 on the config account.
 
@@ -1145,7 +1145,7 @@ async fn fail_withdraw_inactive_stake_with_vault_as_destination() {
     // And we set the amount = 50 and inactive_account = 50 on the stake account.
 
     let mut account = get_account!(context, stake_manager.stake);
-    let mut stake_account = Stake::from_bytes(account.data.as_ref()).unwrap();
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set the stake values
     stake_account.amount = 50;
     stake_account.inactive_amount = 50;

--- a/clients/rust/tests/withdraw_inactive_stake.rs
+++ b/clients/rust/tests/withdraw_inactive_stake.rs
@@ -7,7 +7,7 @@ use paladin_stake_program_client::{
     accounts::{Config, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::WithdrawInactiveStakeBuilder,
-    pdas::{find_stake_pda, find_vault_pda},
+    pdas::{find_validator_stake_pda, find_vault_pda},
 };
 use setup::{
     add_extra_account_metas_for_transfer,
@@ -481,7 +481,7 @@ async fn fail_withdraw_inactive_stake_with_uninitialized_stake_account() {
     // And we set the amount = 50 and inactive_account = 50 on t// And an uninitialized stake account.
 
     let validator_vote = Pubkey::new_unique();
-    let (stake, _) = find_stake_pda(&validator_vote, &config_manager.config);
+    let (stake, _) = find_validator_stake_pda(&validator_vote, &config_manager.config);
 
     context.set_account(
         &stake,

--- a/program/idl.json
+++ b/program/idl.json
@@ -704,7 +704,7 @@
       }
     },
     {
-      "name": "Stake",
+      "name": "ValidatorStake",
       "type": {
         "kind": "struct",
         "fields": [

--- a/program/src/processor/deactivate_stake.rs
+++ b/program/src/processor/deactivate_stake.rs
@@ -9,7 +9,7 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, DeactivateStakeAccounts},
     require,
-    state::{find_stake_pda, Config, Stake, MAX_BASIS_POINTS},
+    state::{find_stake_pda, Config, ValidatorStake, MAX_BASIS_POINTS},
 };
 
 /// Helper to calculate the maximum amount that can be deactivated.
@@ -72,7 +72,7 @@ pub fn process_deactivate_stake(
     );
 
     let data = &mut ctx.accounts.stake.try_borrow_mut_data()?;
-    let stake = bytemuck::try_from_bytes_mut::<Stake>(data)
+    let stake = bytemuck::try_from_bytes_mut::<ValidatorStake>(data)
         .map_err(|_error| ProgramError::InvalidAccountData)?;
 
     require!(

--- a/program/src/processor/deactivate_stake.rs
+++ b/program/src/processor/deactivate_stake.rs
@@ -9,7 +9,7 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, DeactivateStakeAccounts},
     require,
-    state::{find_stake_pda, Config, ValidatorStake, MAX_BASIS_POINTS},
+    state::{find_validator_stake_pda, Config, ValidatorStake, MAX_BASIS_POINTS},
 };
 
 /// Helper to calculate the maximum amount that can be deactivated.
@@ -83,7 +83,7 @@ pub fn process_deactivate_stake(
 
     // validates that the stake account corresponds to the received config account
     let (derivation, _) =
-        find_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
+        find_validator_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
 
     require!(
         ctx.accounts.stake.key == &derivation,

--- a/program/src/processor/harvest_holder_rewards.rs
+++ b/program/src/processor/harvest_holder_rewards.rs
@@ -13,7 +13,7 @@ use crate::{
     require,
     state::{
         calculate_eligible_rewards, create_vault_pda, find_stake_pda, get_vault_pda_signer_seeds,
-        Config, Stake,
+        Config, ValidatorStake,
     },
 };
 
@@ -77,7 +77,7 @@ pub fn process_harvest_holder_rewards(
     );
 
     let mut stake_data = ctx.accounts.stake.try_borrow_mut_data()?;
-    let stake = bytemuck::try_from_bytes_mut::<Stake>(&mut stake_data)
+    let stake = bytemuck::try_from_bytes_mut::<ValidatorStake>(&mut stake_data)
         .map_err(|_error| ProgramError::InvalidAccountData)?;
 
     require!(

--- a/program/src/processor/harvest_holder_rewards.rs
+++ b/program/src/processor/harvest_holder_rewards.rs
@@ -12,7 +12,7 @@ use crate::{
     instruction::accounts::{Context, HarvestHolderRewardsAccounts},
     require,
     state::{
-        calculate_eligible_rewards, create_vault_pda, find_stake_pda, get_vault_pda_signer_seeds,
+        calculate_eligible_rewards, create_vault_pda, find_validator_stake_pda, get_vault_pda_signer_seeds,
         Config, ValidatorStake,
     },
 };
@@ -87,7 +87,7 @@ pub fn process_harvest_holder_rewards(
     );
 
     let (derivation, _) =
-        find_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
+        find_validator_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
 
     require!(
         ctx.accounts.stake.key == &derivation,

--- a/program/src/processor/harvest_holder_rewards.rs
+++ b/program/src/processor/harvest_holder_rewards.rs
@@ -12,8 +12,8 @@ use crate::{
     instruction::accounts::{Context, HarvestHolderRewardsAccounts},
     require,
     state::{
-        calculate_eligible_rewards, create_vault_pda, find_validator_stake_pda, get_vault_pda_signer_seeds,
-        Config, ValidatorStake,
+        calculate_eligible_rewards, create_vault_pda, find_validator_stake_pda,
+        get_vault_pda_signer_seeds, Config, ValidatorStake,
     },
 };
 

--- a/program/src/processor/harvest_stake_rewards.rs
+++ b/program/src/processor/harvest_stake_rewards.rs
@@ -7,7 +7,7 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, HarvestStakeRewardsAccounts},
     require,
-    state::{calculate_eligible_rewards, find_stake_pda, Config, ValidatorStake},
+    state::{calculate_eligible_rewards, find_validator_stake_pda, Config, ValidatorStake},
 };
 
 /// Harvests stake SOL rewards earned by the given stake account.
@@ -68,7 +68,7 @@ pub fn process_harvest_stake_rewards(
     );
 
     let (derivation, _) =
-        find_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
+        find_validator_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
 
     require!(
         ctx.accounts.stake.key == &derivation,

--- a/program/src/processor/harvest_stake_rewards.rs
+++ b/program/src/processor/harvest_stake_rewards.rs
@@ -7,7 +7,7 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, HarvestStakeRewardsAccounts},
     require,
-    state::{calculate_eligible_rewards, find_stake_pda, Config, Stake},
+    state::{calculate_eligible_rewards, find_stake_pda, Config, ValidatorStake},
 };
 
 /// Harvests stake SOL rewards earned by the given stake account.
@@ -58,7 +58,7 @@ pub fn process_harvest_stake_rewards(
     );
 
     let mut stake_data = ctx.accounts.stake.try_borrow_mut_data()?;
-    let stake = bytemuck::try_from_bytes_mut::<Stake>(&mut stake_data)
+    let stake = bytemuck::try_from_bytes_mut::<ValidatorStake>(&mut stake_data)
         .map_err(|_error| ProgramError::InvalidAccountData)?;
 
     require!(

--- a/program/src/processor/inactivate_stake.rs
+++ b/program/src/processor/inactivate_stake.rs
@@ -7,7 +7,7 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, InactivateStakeAccounts},
     require,
-    state::{find_stake_pda, Config, Stake},
+    state::{find_stake_pda, Config, ValidatorStake},
 };
 
 /// Move tokens from deactivating to inactive.
@@ -58,7 +58,7 @@ pub fn process_inactivate_stake(
     );
 
     let data = &mut ctx.accounts.stake.try_borrow_mut_data()?;
-    let stake = bytemuck::try_from_bytes_mut::<Stake>(data)
+    let stake = bytemuck::try_from_bytes_mut::<ValidatorStake>(data)
         .map_err(|_error| ProgramError::InvalidAccountData)?;
 
     require!(

--- a/program/src/processor/inactivate_stake.rs
+++ b/program/src/processor/inactivate_stake.rs
@@ -7,7 +7,7 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, InactivateStakeAccounts},
     require,
-    state::{find_stake_pda, Config, ValidatorStake},
+    state::{find_validator_stake_pda, Config, ValidatorStake},
 };
 
 /// Move tokens from deactivating to inactive.
@@ -70,7 +70,7 @@ pub fn process_inactivate_stake(
     // validates that the stake account corresponds to the received
     // config account
     let (derivation, _) =
-        find_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
+        find_validator_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
 
     require!(
         ctx.accounts.stake.key == &derivation,

--- a/program/src/processor/initialize_stake.rs
+++ b/program/src/processor/initialize_stake.rs
@@ -7,7 +7,9 @@ use solana_program::{
 use crate::{
     instruction::accounts::{Context, InitializeStakeAccounts},
     require,
-    state::{find_stake_pda, get_stake_pda_signer_seeds, Config, ValidatorStake},
+    state::{
+        find_validator_stake_pda, get_validator_stake_pda_signer_seeds, Config, ValidatorStake,
+    },
 };
 
 /// Initializes stake account data for a validator.
@@ -75,7 +77,7 @@ pub fn process_initialize_stake(
     // NOTE: The stake account is created and assigned to the stake program, so it needs
     // to be pre-funded with the minimum rent balance by the caller.
 
-    let (derivation, bump) = find_stake_pda(
+    let (derivation, bump) = find_validator_stake_pda(
         ctx.accounts.validator_vote.key,
         ctx.accounts.config.key,
         program_id,
@@ -96,7 +98,7 @@ pub fn process_initialize_stake(
     // Allocate and assign.
 
     let bump_seed = [bump];
-    let signer_seeds = get_stake_pda_signer_seeds(
+    let signer_seeds = get_validator_stake_pda_signer_seeds(
         ctx.accounts.validator_vote.key,
         ctx.accounts.config.key,
         &bump_seed,

--- a/program/src/processor/initialize_stake.rs
+++ b/program/src/processor/initialize_stake.rs
@@ -7,7 +7,7 @@ use solana_program::{
 use crate::{
     instruction::accounts::{Context, InitializeStakeAccounts},
     require,
-    state::{find_stake_pda, get_stake_pda_signer_seeds, Config, Stake},
+    state::{find_stake_pda, get_stake_pda_signer_seeds, Config, ValidatorStake},
 };
 
 /// Initializes stake account data for a validator.
@@ -103,7 +103,7 @@ pub fn process_initialize_stake(
     );
 
     invoke_signed(
-        &system_instruction::allocate(ctx.accounts.stake.key, Stake::LEN as u64),
+        &system_instruction::allocate(ctx.accounts.stake.key, ValidatorStake::LEN as u64),
         &[ctx.accounts.stake.clone()],
         &[&signer_seeds],
     )?;
@@ -117,9 +117,9 @@ pub fn process_initialize_stake(
     // Initialize the stake account.
 
     let mut data = ctx.accounts.stake.try_borrow_mut_data()?;
-    let stake = bytemuck::from_bytes_mut::<Stake>(&mut data);
+    let stake = bytemuck::from_bytes_mut::<ValidatorStake>(&mut data);
 
-    *stake = Stake::new(withdraw_authority, *ctx.accounts.validator_vote.key);
+    *stake = ValidatorStake::new(withdraw_authority, *ctx.accounts.validator_vote.key);
 
     Ok(())
 }

--- a/program/src/processor/set_authority.rs
+++ b/program/src/processor/set_authority.rs
@@ -8,7 +8,7 @@ use crate::{
         AuthorityType,
     },
     require,
-    state::{Config, Stake},
+    state::{Config, ValidatorStake},
 };
 
 /// Unpacks an initialized account from the given data and
@@ -98,7 +98,7 @@ pub fn process_set_authority(
             config.slash_authority = OptionalNonZeroPubkey(*ctx.accounts.new_authority.key);
         }
         AuthorityType::Stake => {
-            let stake = unpack_initialized_mut!(data, Stake, "stake");
+            let stake = unpack_initialized_mut!(data, ValidatorStake, "stake");
 
             require!(
                 *ctx.accounts.authority.key == stake.authority,

--- a/program/src/processor/slash.rs
+++ b/program/src/processor/slash.rs
@@ -15,7 +15,7 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, SlashAccounts},
     require,
-    state::{create_vault_pda, find_stake_pda, get_vault_pda_signer_seeds, Config, ValidatorStake},
+    state::{create_vault_pda, find_validator_stake_pda, get_vault_pda_signer_seeds, Config, ValidatorStake},
 };
 
 /// Slashes a stake account for the given amount
@@ -81,7 +81,7 @@ pub fn process_slash(
     );
 
     let (derivation, _) =
-        find_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
+        find_validator_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
 
     require!(
         ctx.accounts.stake.key == &derivation,

--- a/program/src/processor/slash.rs
+++ b/program/src/processor/slash.rs
@@ -15,7 +15,7 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, SlashAccounts},
     require,
-    state::{create_vault_pda, find_stake_pda, get_vault_pda_signer_seeds, Config, Stake},
+    state::{create_vault_pda, find_stake_pda, get_vault_pda_signer_seeds, Config, ValidatorStake},
 };
 
 /// Slashes a stake account for the given amount
@@ -71,7 +71,7 @@ pub fn process_slash(
     );
 
     let mut stake_data = ctx.accounts.stake.try_borrow_mut_data()?;
-    let stake = bytemuck::try_from_bytes_mut::<Stake>(&mut stake_data)
+    let stake = bytemuck::try_from_bytes_mut::<ValidatorStake>(&mut stake_data)
         .map_err(|_error| ProgramError::InvalidAccountData)?;
 
     require!(

--- a/program/src/processor/slash.rs
+++ b/program/src/processor/slash.rs
@@ -15,7 +15,10 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, SlashAccounts},
     require,
-    state::{create_vault_pda, find_validator_stake_pda, get_vault_pda_signer_seeds, Config, ValidatorStake},
+    state::{
+        create_vault_pda, find_validator_stake_pda, get_vault_pda_signer_seeds, Config,
+        ValidatorStake,
+    },
 };
 
 /// Slashes a stake account for the given amount

--- a/program/src/processor/stake_tokens.rs
+++ b/program/src/processor/stake_tokens.rs
@@ -8,7 +8,7 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, StakeTokensAccounts},
     require,
-    state::{find_stake_pda, Config, Stake},
+    state::{find_stake_pda, Config, ValidatorStake},
 };
 
 /// Stakes tokens with the given config.
@@ -70,7 +70,7 @@ pub fn process_stake_tokens<'a>(
     );
 
     let mut stake_data = ctx.accounts.stake.try_borrow_mut_data()?;
-    let stake = bytemuck::try_from_bytes_mut::<Stake>(&mut stake_data)
+    let stake = bytemuck::try_from_bytes_mut::<ValidatorStake>(&mut stake_data)
         .map_err(|_error| ProgramError::InvalidAccountData)?;
 
     require!(

--- a/program/src/processor/stake_tokens.rs
+++ b/program/src/processor/stake_tokens.rs
@@ -8,7 +8,7 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, StakeTokensAccounts},
     require,
-    state::{find_stake_pda, Config, ValidatorStake},
+    state::{find_validator_stake_pda, Config, ValidatorStake},
 };
 
 /// Stakes tokens with the given config.
@@ -80,7 +80,7 @@ pub fn process_stake_tokens<'a>(
     );
 
     let (derivation, _) =
-        find_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
+        find_validator_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
 
     require!(
         ctx.accounts.stake.key == &derivation,

--- a/program/src/processor/withdraw_inactive_stake.rs
+++ b/program/src/processor/withdraw_inactive_stake.rs
@@ -8,7 +8,7 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, WithdrawInactiveStakeAccounts},
     require,
-    state::{create_vault_pda, find_stake_pda, get_vault_pda_signer_seeds, Config, Stake},
+    state::{create_vault_pda, find_stake_pda, get_vault_pda_signer_seeds, Config, ValidatorStake},
 };
 
 /// Withdraw inactive staked tokens from the vault
@@ -65,7 +65,7 @@ pub fn process_withdraw_inactive_stake<'a>(
     );
 
     let mut stake_data = ctx.accounts.stake.try_borrow_mut_data()?;
-    let stake = bytemuck::try_from_bytes_mut::<Stake>(&mut stake_data)
+    let stake = bytemuck::try_from_bytes_mut::<ValidatorStake>(&mut stake_data)
         .map_err(|_error| ProgramError::InvalidAccountData)?;
 
     require!(

--- a/program/src/processor/withdraw_inactive_stake.rs
+++ b/program/src/processor/withdraw_inactive_stake.rs
@@ -8,7 +8,10 @@ use crate::{
     error::StakeError,
     instruction::accounts::{Context, WithdrawInactiveStakeAccounts},
     require,
-    state::{create_vault_pda, find_stake_pda, get_vault_pda_signer_seeds, Config, ValidatorStake},
+    state::{
+        create_vault_pda, find_validator_stake_pda, get_vault_pda_signer_seeds, Config,
+        ValidatorStake,
+    },
 };
 
 /// Withdraw inactive staked tokens from the vault
@@ -75,7 +78,7 @@ pub fn process_withdraw_inactive_stake<'a>(
     );
 
     let (derivation, _) =
-        find_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
+        find_validator_stake_pda(&stake.validator_vote, ctx.accounts.config.key, program_id);
 
     require!(
         ctx.accounts.stake.key == &derivation,

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -1,8 +1,8 @@
 pub mod config;
-pub mod stake;
+pub mod validator_stake;
 
 pub use config::*;
-pub use stake::*;
+pub use validator_stake::*;
 
 use solana_program::{
     program_error::ProgramError,

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -33,7 +33,7 @@ pub fn find_vault_pda(config: &Pubkey, program_id: &Pubkey) -> (Pubkey, u8) {
 }
 
 #[inline(always)]
-pub fn find_stake_pda(
+pub fn find_validator_stake_pda(
     validator_vote: &Pubkey,
     config: &Pubkey,
     program_id: &Pubkey,
@@ -54,7 +54,7 @@ pub fn get_vault_pda_signer_seeds<'a>(config: &'a Pubkey, bump_seed: &'a [u8]) -
 }
 
 #[inline(always)]
-pub fn get_stake_pda_signer_seeds<'a>(
+pub fn get_validator_stake_pda_signer_seeds<'a>(
     validator_vote: &'a Pubkey,
     config: &'a Pubkey,
     bump_seed: &'a [u8],

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -40,7 +40,7 @@ pub fn find_stake_pda(
 ) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[
-            "stake::state::stake".as_bytes(),
+            "stake::state::validator_stake".as_bytes(),
             validator_vote.as_ref(),
             config.as_ref(),
         ],
@@ -60,7 +60,7 @@ pub fn get_stake_pda_signer_seeds<'a>(
     bump_seed: &'a [u8],
 ) -> [&'a [u8]; 4] {
     [
-        "stake::state::stake".as_bytes(),
+        "stake::state::validator_stake".as_bytes(),
         validator_vote.as_ref(),
         config.as_ref(),
         bump_seed,

--- a/program/src/state/validator_stake.rs
+++ b/program/src/state/validator_stake.rs
@@ -11,7 +11,7 @@ use super::U128_DEFAULT;
 #[repr(C)]
 #[derive(Clone, Copy, Default, Pod, ShankAccount, SplDiscriminate, Zeroable)]
 #[discriminator_hash_input("stake::state::stake")]
-pub struct Stake {
+pub struct ValidatorStake {
     /// Account disciminator.
     ///
     /// The discriminator is equal to `ArrayDiscriminator:: UNINITIALIZED` when
@@ -50,17 +50,17 @@ pub struct Stake {
     last_seen_stake_rewards_per_token: [u8; 16],
 }
 
-impl Stake {
-    pub const LEN: usize = std::mem::size_of::<Stake>();
+impl ValidatorStake {
+    pub const LEN: usize = std::mem::size_of::<ValidatorStake>();
 
     #[inline(always)]
     pub fn is_initialized(&self) -> bool {
-        self.discriminator.as_slice() == Stake::SPL_DISCRIMINATOR_SLICE
+        self.discriminator.as_slice() == ValidatorStake::SPL_DISCRIMINATOR_SLICE
     }
 
     pub fn new(authority: Pubkey, validator_vote: Pubkey) -> Self {
         Self {
-            discriminator: Stake::SPL_DISCRIMINATOR.into(),
+            discriminator: ValidatorStake::SPL_DISCRIMINATOR.into(),
             amount: u64::default(),
             deactivation_timestamp: Option::default(),
             deactivating_amount: u64::default(),

--- a/program/src/state/validator_stake.rs
+++ b/program/src/state/validator_stake.rs
@@ -10,7 +10,7 @@ use super::U128_DEFAULT;
 /// Data for an amount of tokens staked with a validator
 #[repr(C)]
 #[derive(Clone, Copy, Default, Pod, ShankAccount, SplDiscriminate, Zeroable)]
-#[discriminator_hash_input("stake::state::stake")]
+#[discriminator_hash_input("stake::state::validator_stake")]
 pub struct ValidatorStake {
     /// Account disciminator.
     ///

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -180,7 +180,7 @@ kinobi.update(
     config: {
       size: 144,
     },
-    stake: {
+    validatorStake: {
       size: 136,
     },
   })


### PR DESCRIPTION
This PR renames the `Stake` account to `ValidatorStake` to reflect the fact that there will be two types of stakers.