### PR TITLE
Fixup sync test

### DIFF
--- a/clients/rust/tests/setup/mod.rs
+++ b/clients/rust/tests/setup/mod.rs
@@ -18,7 +18,7 @@ pub mod vote;
 /// Scaling factor for rewards per token (1e9).
 pub const REWARDS_PER_TOKEN_SCALING_FACTOR: u128 = 1_000_000_000;
 
-pub async fn setup() -> ProgramTestContext {
+pub fn new_program_test() -> ProgramTest {
     let mut program_test = ProgramTest::new(
         "paladin_stake_program",
         paladin_stake_program_client::ID,
@@ -34,6 +34,11 @@ pub async fn setup() -> ProgramTestContext {
         paladin_sol_stake_view_program_client::ID,
         None,
     );
+    program_test
+}
+
+pub async fn setup() -> ProgramTestContext {
+    let program_test = new_program_test();
     program_test.start_with_context().await
 }
 

--- a/clients/rust/tests/setup/validator_stake.rs
+++ b/clients/rust/tests/setup/validator_stake.rs
@@ -39,6 +39,25 @@ impl ValidatorStakeManager {
             vote,
         }
     }
+
+    pub async fn new_with_vote(
+        context: &mut ProgramTestContext,
+        config: &Pubkey,
+        vote: Pubkey,
+    ) -> Self {
+        let authority = Keypair::new();
+        let validator = Pubkey::new_unique();
+
+        // And a stake account.
+        let stake = create_validator_stake(context, &vote, config).await;
+
+        Self {
+            stake,
+            authority,
+            validator,
+            vote,
+        }
+    }
 }
 
 pub async fn create_validator_stake(

--- a/clients/rust/tests/setup/vote.rs
+++ b/clients/rust/tests/setup/vote.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test-sbf")]
 #![allow(dead_code)]
 
-use solana_program_test::ProgramTestContext;
+use solana_program_test::{ProgramTest, ProgramTestContext};
 use solana_sdk::{
     account::Account,
     clock::Epoch,
@@ -42,5 +42,30 @@ pub async fn create_vote_account_with_program_id(
     };
 
     context.set_account(&vote, &vote_account.into());
+    vote
+}
+
+pub fn add_vote_account(
+    program_test: &mut ProgramTest,
+    node: &Pubkey,
+    authority: &Pubkey,
+) -> Pubkey {
+    let vote = Pubkey::new_unique();
+
+    let mut vote_state = VoteState::new_rand_for_tests(*node, 0);
+    vote_state.authorized_withdrawer = *authority;
+
+    let mut data = vec![0; VoteState::size_of()];
+    VoteState::serialize(&VoteStateVersions::new_current(vote_state), &mut data).unwrap();
+
+    let vote_account = Account {
+        lamports: 5_000_000_000, // 5 SOL
+        data,
+        owner: solana_sdk::vote::program::ID,
+        executable: false,
+        rent_epoch: Epoch::default(),
+    };
+
+    program_test.add_account(vote, vote_account.into());
     vote
 }


### PR DESCRIPTION
#### Problem

The sync test is failing because it's setting an account directly into the bank forks, which is causing the account hash calculation to fail during warp.

#### Summary of changes

Set the vote account in before starting the program test.