### PR TITLE
Refactor: `UpdateConfig`

### DIFF
--- a/clients/js/src/generated/types/configField.ts
+++ b/clients/js/src/generated/types/configField.ts
@@ -27,11 +27,13 @@ import {
 
 export type ConfigField =
   | { __kind: 'CooldownTimeSeconds'; fields: readonly [bigint] }
-  | { __kind: 'MaxDeactivationBasisPoints'; fields: readonly [number] };
+  | { __kind: 'MaxDeactivationBasisPoints'; fields: readonly [number] }
+  | { __kind: 'SyncRewardsLamports'; fields: readonly [bigint] };
 
 export type ConfigFieldArgs =
   | { __kind: 'CooldownTimeSeconds'; fields: readonly [number | bigint] }
-  | { __kind: 'MaxDeactivationBasisPoints'; fields: readonly [number] };
+  | { __kind: 'MaxDeactivationBasisPoints'; fields: readonly [number] }
+  | { __kind: 'SyncRewardsLamports'; fields: readonly [number | bigint] };
 
 export function getConfigFieldEncoder(): Encoder<ConfigFieldArgs> {
   return getDiscriminatedUnionEncoder([
@@ -42,6 +44,10 @@ export function getConfigFieldEncoder(): Encoder<ConfigFieldArgs> {
     [
       'MaxDeactivationBasisPoints',
       getStructEncoder([['fields', getTupleEncoder([getU16Encoder()])]]),
+    ],
+    [
+      'SyncRewardsLamports',
+      getStructEncoder([['fields', getTupleEncoder([getU64Encoder()])]]),
     ],
   ]);
 }
@@ -55,6 +61,10 @@ export function getConfigFieldDecoder(): Decoder<ConfigField> {
     [
       'MaxDeactivationBasisPoints',
       getStructDecoder([['fields', getTupleDecoder([getU16Decoder()])]]),
+    ],
+    [
+      'SyncRewardsLamports',
+      getStructDecoder([['fields', getTupleDecoder([getU64Decoder()])]]),
     ],
   ]);
 }
@@ -87,6 +97,18 @@ export function configField(
   ConfigFieldArgs,
   '__kind',
   'MaxDeactivationBasisPoints'
+>;
+export function configField(
+  kind: 'SyncRewardsLamports',
+  data: GetDiscriminatedUnionVariantContent<
+    ConfigFieldArgs,
+    '__kind',
+    'SyncRewardsLamports'
+  >['fields']
+): GetDiscriminatedUnionVariant<
+  ConfigFieldArgs,
+  '__kind',
+  'SyncRewardsLamports'
 >;
 export function configField<K extends ConfigFieldArgs['__kind'], Data>(
   kind: K,

--- a/clients/rust/src/generated/types/config_field.rs
+++ b/clients/rust/src/generated/types/config_field.rs
@@ -13,4 +13,5 @@ use borsh::BorshSerialize;
 pub enum ConfigField {
     CooldownTimeSeconds(u64),
     MaxDeactivationBasisPoints(u16),
+    SyncRewardsLamports(u64),
 }

--- a/clients/rust/tests/update_config.rs
+++ b/clients/rust/tests/update_config.rs
@@ -295,7 +295,7 @@ async fn update_sync_rewards_lamports() {
     let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(config_account.sync_rewards_lamports, 1_000_000);
 
-    // When we update the cooldown time config.
+    // When we update the sync rewards lamports.
 
     let ix = UpdateConfigBuilder::new()
         .config(config.pubkey())
@@ -311,7 +311,7 @@ async fn update_sync_rewards_lamports() {
     );
     context.banks_client.process_transaction(tx).await.unwrap();
 
-    // Then the cooldown time was updated.
+    // Then the sync rewards lamports field was updated.
 
     let account = get_account!(context, config.pubkey());
     let config_account = Config::from_bytes(account.data.as_ref()).unwrap();

--- a/program/idl.json
+++ b/program/idl.json
@@ -1164,6 +1164,12 @@
             "fields": [
               "u16"
             ]
+          },
+          {
+            "name": "SyncRewardsLamports",
+            "fields": [
+              "u64"
+            ]
           }
         ]
       }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -696,6 +696,10 @@ impl StakeInstruction {
                         data.push(1);
                         data.extend_from_slice(&value.to_le_bytes());
                     }
+                    ConfigField::SyncRewardsLamports(value) => {
+                        data.push(2);
+                        data.extend_from_slice(&value.to_le_bytes());
+                    }
                 }
                 data
             }
@@ -784,6 +788,11 @@ impl StakeInstruction {
                             rest, 0, 2
                         ]))
                     }
+                    Some((&2, rest)) if rest.len() == 8 => {
+                        ConfigField::SyncRewardsLamports(u64::from_le_bytes(*array_ref![
+                            rest, 0, 8
+                        ]))
+                    }
                     _ => return Err(ProgramError::InvalidInstructionData),
                 };
 
@@ -828,6 +837,8 @@ pub enum ConfigField {
     CooldownTimeSeconds(u64),
     /// Total proportion that can be deactivated at once, in basis points
     MaxDeactivationBasisPoints(u16),
+    /// Lamports amount paid to for syncing a SOL stake account.
+    SyncRewardsLamports(u64),
 }
 
 #[cfg(test)]

--- a/program/src/processor/update_config.rs
+++ b/program/src/processor/update_config.rs
@@ -80,6 +80,9 @@ pub fn process_update_config(
 
                 config.max_deactivation_basis_points = points;
             }
+            ConfigField::SyncRewardsLamports(lamports) => {
+                config.sync_rewards_lamports = lamports;
+            }
         }
     } else {
         return err!(StakeError::AuthorityNotSet);


### PR DESCRIPTION
### Problem

The `sync_rewards_lamports` field was added to `Config` as part of the `HarvestSyncRewards` instruction, but it is not currently possible to update its value after the creation of the `Config`.

### Solution

This PR refactors the `UpdateConfig` processor to support updating the value of `sync_rewards_lamports`. It also adds a test for it.