### PR TITLE
Refactor: `WithdrawInactiveStake` tests

### DIFF
--- a/.github/actions/purge/action.yml
+++ b/.github/actions/purge/action.yml
@@ -1,0 +1,31 @@
+name: Purge
+
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# WARNING: THIS IS NOT TO BE USED LOCALLY, BUT ONLY IN GITHUB ACTIONS TO CLEAR
+# DISK SPACE ON UBUNTU RUNNER.
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+runs:
+  using: "composite"
+  steps:
+    - name: Purge runner
+      shell: bash
+      run: |
+        set -e
+
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /usr/share/mysql
+        sudo rm -rf /usr/share/az_*
+        sudo rm -rf /usr/share/postgresql-common
+
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/az
+        sudo rm -rf /opt/pipx
+        sudo rm -rf /opt/microsoft
+        sudo rm -rf /opt/google
+        sudo rm -rf /opt/hostedtoolcache
+
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/local/lib/heroku
+        sudo rm -rf /imagegeneration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,6 +208,8 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
+      - name: Purge environment
+        uses: ./.github/actions/purge
       - name: Setup environment
         uses: ./.github/actions/setup
         with:


### PR DESCRIPTION
### Problem

After the refactoring of the stake account into `ValidatorStake` and `SolStakerStake`, the tests were disabled by adding `.rs_` as an extension to the test file.

### Solution

This PR reverts the extension change. It also adds two new tests:
* `withdraw_inactive_stake_with_sol_staker_stake`
* `fail_withdraw_inactive_stake_with_sol_staker_stake_without_inactive_stake`

These are specific tests for `SolStakerStake` accounts.