### PR TITLE
Refactor: `HarvestHolderRewards` tests

### DIFF
--- a/clients/rust/tests/harvest_holder_rewards.rs
+++ b/clients/rust/tests/harvest_holder_rewards.rs
@@ -980,13 +980,13 @@ async fn sol_staker_stake_harvest_holder_rewards() {
 
     // When we harvest the holder rewards for the SOL staker stake account.
     //
-    // We are expecting the rewards to be 2 SOL.
+    // We are expecting the rewards to be 1.6 SOL.
     //
     // Calculation:
     //   - total staked: 100
     //   - holder rewards: 4 SOL
     //   - rewards per token: 4_000_000_000 / 100 = 40_000_000 (0.04 SOL)
-    //   - rewards for 40 staked: 40_000_000 * 40 = 1_600_000_000 (2 SOL)
+    //   - rewards for 40 staked: 40_000_000 * 40 = 1_600_000_000 (1.6 SOL)
 
     let destination = Pubkey::new_unique();
 

--- a/clients/rust/tests/harvest_holder_rewards.rs
+++ b/clients/rust/tests/harvest_holder_rewards.rs
@@ -5,7 +5,7 @@ mod setup;
 use borsh::BorshSerialize;
 use paladin_rewards_program_client::accounts::HolderRewards;
 use paladin_stake_program_client::{
-    accounts::{Config, ValidatorStake},
+    accounts::{Config, SolStakerStake, ValidatorStake},
     errors::PaladinStakeProgramError,
     instructions::HarvestHolderRewardsBuilder,
     pdas::{find_validator_stake_pda, find_vault_pda},
@@ -13,6 +13,8 @@ use paladin_stake_program_client::{
 use setup::{
     config::ConfigManager,
     rewards::{create_holder_rewards, create_holder_rewards_pool},
+    setup,
+    sol_staker_stake::SolStakerStakeManager,
     validator_stake::ValidatorStakeManager,
 };
 use solana_program_test::{tokio, ProgramTest};
@@ -25,7 +27,7 @@ use solana_sdk::{
 };
 
 #[tokio::test]
-async fn harvest_holder_rewards() {
+async fn validator_stake_harvest_holder_rewards() {
     let mut program_test = ProgramTest::new(
         "paladin_stake_program",
         paladin_stake_program_client::ID,
@@ -159,7 +161,7 @@ async fn harvest_holder_rewards() {
 }
 
 #[tokio::test]
-async fn harvest_holder_rewards_with_no_rewards_available() {
+async fn validator_stake_harvest_holder_rewards_with_no_rewards_available() {
     let mut program_test = ProgramTest::new(
         "paladin_stake_program",
         paladin_stake_program_client::ID,
@@ -264,7 +266,7 @@ async fn harvest_holder_rewards_with_no_rewards_available() {
 }
 
 #[tokio::test]
-async fn harvest_holder_rewards_after_harvesting() {
+async fn validator_stake_harvest_holder_rewards_after_harvesting() {
     let mut program_test = ProgramTest::new(
         "paladin_stake_program",
         paladin_stake_program_client::ID,
@@ -411,7 +413,7 @@ async fn harvest_holder_rewards_after_harvesting() {
 }
 
 #[tokio::test]
-async fn fail_harvest_holder_rewards_with_wrong_authority() {
+async fn validator_stake_fail_harvest_holder_rewards_with_wrong_authority() {
     let mut program_test = ProgramTest::new(
         "paladin_stake_program",
         paladin_stake_program_client::ID,
@@ -687,7 +689,7 @@ async fn fail_harvest_holder_rewards_with_uninitialized_stake() {
 
     // Then we expect an error.
 
-    assert_instruction_error!(err, InstructionError::UninitializedAccount);
+    assert_instruction_error!(err, InstructionError::InvalidAccountData);
 }
 
 #[tokio::test]
@@ -895,4 +897,524 @@ async fn fail_harvest_holder_rewards_with_invalid_destination() {
     // Then we expect an error.
 
     assert_custom_error!(err, PaladinStakeProgramError::InvalidDestinationAccount);
+}
+
+#[tokio::test]
+async fn sol_staker_stake_harvest_holder_rewards() {
+    let mut context = setup().await;
+
+    // Given a config account with 100 staked amount.
+
+    let config_manager = ConfigManager::new(&mut context).await;
+
+    let mut account = get_account!(context, config_manager.config);
+    let mut config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the total amount delegated
+    config_account.token_amount_delegated = 100;
+    account.data = config_account.try_to_vec().unwrap();
+    context.set_account(&config_manager.config, &account.into());
+
+    // And 4 SOL rewards on its vault account.
+
+    let mut account = get_account!(context, config_manager.vault);
+    account.lamports = account.lamports.saturating_add(4_000_000_000);
+    let rewards_lamports = account.lamports;
+    context.set_account(&config_manager.vault, &account.into());
+
+    // And a validator stake account wiht a 40 total staked amount.
+
+    let validator_stake_manager =
+        ValidatorStakeManager::new(&mut context, &config_manager.config).await;
+
+    let mut account = get_account!(context, validator_stake_manager.stake);
+    let mut validator_stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the amount to 40
+    validator_stake_account.total_staked_token_amount = 40;
+
+    account.data = validator_stake_account.try_to_vec().unwrap();
+    context.set_account(&validator_stake_manager.stake, &account.into());
+
+    // And a sol staker stake account wiht a 40 total staked amount.
+
+    let sol_staker_stake_manager = SolStakerStakeManager::new(
+        &mut context,
+        &config_manager.config,
+        &validator_stake_manager.stake,
+        &validator_stake_manager.vote,
+        1_000_000_000,
+    )
+    .await;
+
+    let mut account = get_account!(context, sol_staker_stake_manager.stake);
+    let mut stake_account = SolStakerStake::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the amount to 40
+    stake_account.delegation.amount = 40;
+
+    account.data = stake_account.try_to_vec().unwrap();
+    context.set_account(&sol_staker_stake_manager.stake, &account.into());
+
+    // And we initialize the holder rewards accounts.
+
+    let holder_rewards_pool = create_holder_rewards_pool(
+        &mut context,
+        &config_manager.mint,
+        &config_manager.mint_authority,
+    )
+    .await;
+
+    let holder_rewards = create_holder_rewards(
+        &mut context,
+        &holder_rewards_pool,
+        &config_manager.mint,
+        &config_manager.vault,
+    )
+    .await;
+
+    let mut account = get_account!(context, holder_rewards);
+    let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+
+    account.data = holder_rewards_account.try_to_vec().unwrap();
+    context.set_account(&holder_rewards, &account.into());
+
+    // When we harvest the holder rewards for the SOL staker stake account.
+    //
+    // We are expecting the rewards to be 2 SOL.
+    //
+    // Calculation:
+    //   - total staked: 100
+    //   - holder rewards: 4 SOL
+    //   - rewards per token: 4_000_000_000 / 100 = 40_000_000 (0.04 SOL)
+    //   - rewards for 40 staked: 40_000_000 * 40 = 1_600_000_000 (2 SOL)
+
+    let destination = Pubkey::new_unique();
+
+    let harvest_holder_rewards_ix = HarvestHolderRewardsBuilder::new()
+        .config(config_manager.config)
+        .stake(sol_staker_stake_manager.stake)
+        .vault(config_manager.vault)
+        .holder_rewards(holder_rewards)
+        .vault_authority(find_vault_pda(&config_manager.config).0)
+        .stake_authority(sol_staker_stake_manager.authority.pubkey())
+        .destination(destination)
+        .mint(config_manager.mint)
+        .token_program(spl_token_2022::ID)
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[harvest_holder_rewards_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &sol_staker_stake_manager.authority],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Then the destination account has the rewards.
+
+    let account = get_account!(context, destination);
+    assert_eq!(account.lamports, 1_600_000_000);
+
+    // And there should be rewards left on the vault account.
+
+    let account = get_account!(context, config_manager.vault);
+    assert_eq!(
+        account.lamports,
+        rewards_lamports.saturating_sub(1_600_000_000)
+    );
+
+    // And the stake account last seen holder rewards per token is update.
+
+    let account = get_account!(context, sol_staker_stake_manager.stake);
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(
+        stake_account.delegation.last_seen_holder_rewards_per_token,
+        40_000_000 * 1_000_000_000
+    );
+
+    // And the vault authority did not keep any lamports (the account should not exist).
+
+    let account = context
+        .banks_client
+        .get_account(find_vault_pda(&config_manager.config).0)
+        .await
+        .unwrap();
+
+    assert!(account.is_none());
+}
+
+#[tokio::test]
+async fn sol_staker_stake_harvest_holder_rewards_with_no_rewards_available() {
+    let mut context = setup().await;
+
+    // Given a config account with 100 staked amount.
+
+    let config_manager = ConfigManager::new(&mut context).await;
+
+    let mut account = get_account!(context, config_manager.config);
+    let mut config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the total amount delegated
+    config_account.token_amount_delegated = 100;
+    account.data = config_account.try_to_vec().unwrap();
+    context.set_account(&config_manager.config, &account.into());
+
+    // And 4 SOL rewards on its vault account.
+
+    let mut account = get_account!(context, config_manager.vault);
+    account.lamports = account.lamports.saturating_add(4_000_000_000);
+    let rewards_lamports = account.lamports;
+    context.set_account(&config_manager.vault, &account.into());
+
+    // And a stake account wiht no staked amount.
+
+    let validator_stake_manager =
+        ValidatorStakeManager::new(&mut context, &config_manager.config).await;
+
+    // And a sol staker stake account wiht no staked amount.
+
+    let sol_staker_stake_manager = SolStakerStakeManager::new(
+        &mut context,
+        &config_manager.config,
+        &validator_stake_manager.stake,
+        &validator_stake_manager.vote,
+        1_000_000_000,
+    )
+    .await;
+
+    // And we initialize the holder rewards accounts.
+
+    let holder_rewards_pool = create_holder_rewards_pool(
+        &mut context,
+        &config_manager.mint,
+        &config_manager.mint_authority,
+    )
+    .await;
+
+    let holder_rewards = create_holder_rewards(
+        &mut context,
+        &holder_rewards_pool,
+        &config_manager.mint,
+        &config_manager.vault,
+    )
+    .await;
+
+    let mut account = get_account!(context, holder_rewards);
+    let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+
+    account.data = holder_rewards_account.try_to_vec().unwrap();
+    context.set_account(&holder_rewards, &account.into());
+
+    // And we harvest the holder rewards.
+
+    let destination = Pubkey::new_unique();
+
+    let harvest_holder_rewards_ix = HarvestHolderRewardsBuilder::new()
+        .config(config_manager.config)
+        .stake(sol_staker_stake_manager.stake)
+        .vault(config_manager.vault)
+        .holder_rewards(holder_rewards)
+        .vault_authority(find_vault_pda(&config_manager.config).0)
+        .stake_authority(sol_staker_stake_manager.authority.pubkey())
+        .destination(destination)
+        .mint(config_manager.mint)
+        .token_program(spl_token_2022::ID)
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[harvest_holder_rewards_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &sol_staker_stake_manager.authority],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Then the destination should not receive any rewards (account should not exist).
+
+    let account = context.banks_client.get_account(destination).await.unwrap();
+    assert!(account.is_none());
+
+    // And the rewards should be on the vault account.
+
+    let account = get_account!(context, config_manager.vault);
+    assert_eq!(account.lamports, rewards_lamports);
+
+    // And the stake account last seen holder rewards per token is not updated.
+
+    let account = get_account!(context, sol_staker_stake_manager.stake);
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(
+        stake_account.delegation.last_seen_holder_rewards_per_token,
+        0
+    );
+}
+
+#[tokio::test]
+async fn sol_staker_stake_harvest_holder_rewards_after_harvesting() {
+    let mut context = setup().await;
+
+    // Given a config account with 100 staked amount.
+
+    let config_manager = ConfigManager::new(&mut context).await;
+
+    let mut account = get_account!(context, config_manager.config);
+    let mut config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the total amount delegated
+    config_account.token_amount_delegated = 100;
+    account.data = config_account.try_to_vec().unwrap();
+    context.set_account(&config_manager.config, &account.into());
+
+    // And 4 SOL rewards on its vault account.
+
+    let mut account = get_account!(context, config_manager.vault);
+    account.lamports = account.lamports.saturating_add(4_000_000_000);
+    let rewards_lamports = account.lamports;
+    context.set_account(&config_manager.vault, &account.into());
+
+    // And a stake account wiht a 50 staked amount.
+
+    let validator_stake_manager =
+        ValidatorStakeManager::new(&mut context, &config_manager.config).await;
+
+    let mut account = get_account!(context, validator_stake_manager.stake);
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the total staked amount to 50
+    stake_account.total_staked_token_amount = 50;
+
+    account.data = stake_account.try_to_vec().unwrap();
+    context.set_account(&validator_stake_manager.stake, &account.into());
+
+    // And a sol staker stake account wiht a 50 total staked amount.
+
+    let sol_staker_stake_manager = SolStakerStakeManager::new(
+        &mut context,
+        &config_manager.config,
+        &validator_stake_manager.stake,
+        &validator_stake_manager.vote,
+        1_000_000_000,
+    )
+    .await;
+
+    let mut account = get_account!(context, sol_staker_stake_manager.stake);
+    let mut stake_account = SolStakerStake::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the amount to 50
+    stake_account.delegation.amount = 50;
+
+    account.data = stake_account.try_to_vec().unwrap();
+    context.set_account(&sol_staker_stake_manager.stake, &account.into());
+
+    // And we initialize the holder rewards accounts.
+
+    let holder_rewards_pool = create_holder_rewards_pool(
+        &mut context,
+        &config_manager.mint,
+        &config_manager.mint_authority,
+    )
+    .await;
+
+    let holder_rewards = create_holder_rewards(
+        &mut context,
+        &holder_rewards_pool,
+        &config_manager.mint,
+        &config_manager.vault,
+    )
+    .await;
+
+    let mut account = get_account!(context, holder_rewards);
+    let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+
+    account.data = holder_rewards_account.try_to_vec().unwrap();
+    context.set_account(&holder_rewards, &account.into());
+
+    // And we harvest the holder rewards.
+
+    let destination = Pubkey::new_unique();
+
+    let harvest_holder_rewards_ix = HarvestHolderRewardsBuilder::new()
+        .config(config_manager.config)
+        .stake(sol_staker_stake_manager.stake)
+        .vault(config_manager.vault)
+        .holder_rewards(holder_rewards)
+        .vault_authority(find_vault_pda(&config_manager.config).0)
+        .stake_authority(sol_staker_stake_manager.authority.pubkey())
+        .destination(destination)
+        .mint(config_manager.mint)
+        .token_program(spl_token_2022::ID)
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[harvest_holder_rewards_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &sol_staker_stake_manager.authority],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    let account = get_account!(context, destination);
+    assert_eq!(account.lamports, 2_000_000_000);
+
+    // When we harvest the holder rewards again.
+
+    let second_destination = Pubkey::new_unique();
+
+    let harvest_holder_rewards_ix = HarvestHolderRewardsBuilder::new()
+        .config(config_manager.config)
+        .stake(sol_staker_stake_manager.stake)
+        .vault(config_manager.vault)
+        .holder_rewards(holder_rewards)
+        .vault_authority(find_vault_pda(&config_manager.config).0)
+        .stake_authority(sol_staker_stake_manager.authority.pubkey())
+        .destination(second_destination)
+        .mint(config_manager.mint)
+        .token_program(spl_token_2022::ID)
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[harvest_holder_rewards_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &sol_staker_stake_manager.authority],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Then the second destination account shoud have no rewards.
+
+    let account = context
+        .banks_client
+        .get_account(second_destination)
+        .await
+        .unwrap();
+    assert!(account.is_none());
+
+    // And there should be rewards left on the vault account.
+
+    let account = get_account!(context, config_manager.vault);
+    assert_eq!(
+        account.lamports,
+        rewards_lamports.saturating_sub(2_000_000_000)
+    );
+
+    // And the stake account last seen holder rewards per token is update.
+
+    let account = get_account!(context, sol_staker_stake_manager.stake);
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(
+        stake_account.delegation.last_seen_holder_rewards_per_token,
+        40_000_000 * 1_000_000_000
+    );
+}
+
+#[tokio::test]
+async fn sol_staker_stake_fail_harvest_holder_rewards_with_wrong_authority() {
+    let mut context = setup().await;
+
+    // Given a config account with 100 staked amount.
+
+    let config_manager = ConfigManager::new(&mut context).await;
+
+    let mut account = get_account!(context, config_manager.config);
+    let mut config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the total amount delegated
+    config_account.token_amount_delegated = 100;
+    account.data = config_account.try_to_vec().unwrap();
+    context.set_account(&config_manager.config, &account.into());
+
+    // And 4 SOL rewards on its vault account.
+
+    let mut account = get_account!(context, config_manager.vault);
+    account.lamports = account.lamports.saturating_add(4_000_000_000);
+    context.set_account(&config_manager.vault, &account.into());
+
+    // And a stake account wiht a 50 staked amount.
+
+    let validator_stake_manager =
+        ValidatorStakeManager::new(&mut context, &config_manager.config).await;
+
+    let mut account = get_account!(context, validator_stake_manager.stake);
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the total staked amount to 50
+    stake_account.total_staked_token_amount = 50;
+
+    account.data = stake_account.try_to_vec().unwrap();
+    context.set_account(&validator_stake_manager.stake, &account.into());
+
+    // And a sol staker stake account wiht a 50 total staked amount.
+
+    let sol_staker_stake_manager = SolStakerStakeManager::new(
+        &mut context,
+        &config_manager.config,
+        &validator_stake_manager.stake,
+        &validator_stake_manager.vote,
+        1_000_000_000,
+    )
+    .await;
+
+    let mut account = get_account!(context, sol_staker_stake_manager.stake);
+    let mut stake_account = SolStakerStake::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the amount to 50
+    stake_account.delegation.amount = 50;
+
+    account.data = stake_account.try_to_vec().unwrap();
+    context.set_account(&sol_staker_stake_manager.stake, &account.into());
+
+    // And we initialize the holder rewards accounts.
+
+    let holder_rewards_pool = create_holder_rewards_pool(
+        &mut context,
+        &config_manager.mint,
+        &config_manager.mint_authority,
+    )
+    .await;
+
+    let holder_rewards = create_holder_rewards(
+        &mut context,
+        &holder_rewards_pool,
+        &config_manager.mint,
+        &config_manager.vault,
+    )
+    .await;
+
+    let mut account = get_account!(context, holder_rewards);
+    let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+
+    account.data = holder_rewards_account.try_to_vec().unwrap();
+    context.set_account(&holder_rewards, &account.into());
+
+    // When we try to harvest the holder rewards with the wrong authority.
+
+    let fake_authority = Keypair::new();
+    let destination = Pubkey::new_unique();
+
+    let harvest_holder_rewards_ix = HarvestHolderRewardsBuilder::new()
+        .config(config_manager.config)
+        .stake(sol_staker_stake_manager.stake)
+        .vault(config_manager.vault)
+        .holder_rewards(holder_rewards)
+        .vault_authority(find_vault_pda(&config_manager.config).0)
+        .stake_authority(fake_authority.pubkey())
+        .destination(destination)
+        .mint(config_manager.mint)
+        .token_program(spl_token_2022::ID)
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[harvest_holder_rewards_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &fake_authority],
+        context.last_blockhash,
+    );
+    let err = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    // Then we expect an error.
+
+    assert_custom_error!(err, PaladinStakeProgramError::InvalidAuthority);
 }


### PR DESCRIPTION
This PR refactors the `HarvestHolderRewards` instruction tests to handle both `ValidatorStake` and `SolStakerStake` accounts.