### PR TITLE
Fix: refresh blockhash on tests

### DIFF
--- a/clients/rust/tests/setup/sol_staker_stake.rs
+++ b/clients/rust/tests/setup/sol_staker_stake.rs
@@ -90,13 +90,19 @@ pub async fn create_sol_staker_stake(
         .sol_stake_view_program(paladin_sol_stake_view_program_client::ID)
         .instruction();
 
+    context.get_new_latest_blockhash().await.unwrap();
+
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix, initialize_ix],
         Some(&context.payer.pubkey()),
         &[&context.payer],
         context.last_blockhash,
     );
-    context.banks_client.process_transaction(tx).await.unwrap();
+    context
+        .banks_client
+        .process_transaction_with_metadata(tx)
+        .await
+        .unwrap();
 
     stake_pda
 }

--- a/clients/rust/tests/setup/stake.rs
+++ b/clients/rust/tests/setup/stake.rs
@@ -20,6 +20,8 @@ pub async fn create_stake_account(
     let rent = context.banks_client.get_rent().await.unwrap();
     let lamports = rent.minimum_balance(std::mem::size_of::<StakeStateV2>()) + stake_amount;
 
+    context.get_new_latest_blockhash().await.unwrap();
+
     let transaction = Transaction::new_signed_with_payer(
         &create_account(
             &context.payer.pubkey(),
@@ -34,7 +36,7 @@ pub async fn create_stake_account(
     );
     context
         .banks_client
-        .process_transaction(transaction)
+        .process_transaction_with_metadata(transaction)
         .await
         .unwrap();
 


### PR DESCRIPTION
This PR adds a couple of calls to `get_new_latest_blockhash()` and `process_transaction_with_metadata(...)` to avoid failures when running the tests on CI.