### PR TITLE
Processor: Increase rewards per token precision

### DIFF
--- a/clients/rust/tests/distribute_rewards.rs
+++ b/clients/rust/tests/distribute_rewards.rs
@@ -66,7 +66,7 @@ async fn distribute_rewards() {
     assert_eq!(
         config_account.accumulated_stake_rewards_per_token,
         1_000_000_000u128
-            // accumulated rewards are stored with a 1e9 scaling factor
+            // accumulated rewards are stored with a 1e18 scaling factor
             .checked_mul(REWARDS_PER_TOKEN_SCALING_FACTOR)
             .unwrap()
     );

--- a/clients/rust/tests/harvest_holder_rewards.rs
+++ b/clients/rust/tests/harvest_holder_rewards.rs
@@ -90,7 +90,8 @@ async fn validator_stake_harvest_holder_rewards() {
     let mut account = get_account!(context, holder_rewards);
     let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
     // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
-    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+    holder_rewards_account.last_accumulated_rewards_per_token =
+        40_000_000 * 1_000_000_000_000_000_000;
 
     account.data = holder_rewards_account.try_to_vec().unwrap();
     context.set_account(&holder_rewards, &account.into());
@@ -102,8 +103,8 @@ async fn validator_stake_harvest_holder_rewards() {
     // Calculation:
     //   - total staked: 100
     //   - holder rewards: 4 SOL
-    //   - rewards per token: 4_000_000_000 / 100 = 40_000_000 (0.04 SOL)
-    //   - rewards for 50 staked: 40_000_000 * 50 = 2_000_000_000 (2 SOL)
+    //   - rewards per token: 4_000_000_000_000_000_000 / 100 = 40_000_000_000_000_000 (0.04 SOL)
+    //   - rewards for 50 staked: 40_000_000_000_000_000 * 50 = 2_000_000_000_000_000_000 (2 SOL)
 
     let destination = Pubkey::new_unique();
 
@@ -146,7 +147,7 @@ async fn validator_stake_harvest_holder_rewards() {
     let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         stake_account.delegation.last_seen_holder_rewards_per_token,
-        40_000_000 * 1_000_000_000
+        40_000_000 * 1_000_000_000_000_000_000
     );
 
     // And the vault authority did not keep any lamports (the account should not exist).
@@ -215,8 +216,9 @@ async fn validator_stake_harvest_holder_rewards_with_no_rewards_available() {
 
     let mut account = get_account!(context, holder_rewards);
     let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
-    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
-    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+    // "manually" set last accumulated rewards per token to 40_000_000_000_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token =
+        40_000_000 * 1_000_000_000_000_000_000;
 
     account.data = holder_rewards_account.try_to_vec().unwrap();
     context.set_account(&holder_rewards, &account.into());
@@ -328,8 +330,9 @@ async fn validator_stake_harvest_holder_rewards_after_harvesting() {
 
     let mut account = get_account!(context, holder_rewards);
     let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
-    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
-    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+    // "manually" set last accumulated rewards per token to 40_000_000_000_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token =
+        40_000_000 * 1_000_000_000_000_000_000;
 
     account.data = holder_rewards_account.try_to_vec().unwrap();
     context.set_account(&holder_rewards, &account.into());
@@ -408,7 +411,7 @@ async fn validator_stake_harvest_holder_rewards_after_harvesting() {
     let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         stake_account.delegation.last_seen_holder_rewards_per_token,
-        40_000_000 * 1_000_000_000
+        40_000_000 * 1_000_000_000_000_000_000
     );
 }
 
@@ -474,8 +477,9 @@ async fn validator_stake_fail_harvest_holder_rewards_with_wrong_authority() {
 
     let mut account = get_account!(context, holder_rewards);
     let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
-    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
-    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+    // "manually" set last accumulated rewards per token to 40_000_000_000_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token =
+        40_000_000 * 1_000_000_000_000_000_000;
 
     account.data = holder_rewards_account.try_to_vec().unwrap();
     context.set_account(&holder_rewards, &account.into());
@@ -754,8 +758,9 @@ async fn fail_harvest_holder_rewards_with_wrong_config() {
 
     let mut account = get_account!(context, holder_rewards);
     let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
-    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
-    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+    // "manually" set last accumulated rewards per token to 40_000_000_000_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token =
+        40_000_000 * 1_000_000_000_000_000_000;
 
     account.data = holder_rewards_account.try_to_vec().unwrap();
     context.set_account(&holder_rewards, &account.into());
@@ -859,8 +864,9 @@ async fn fail_harvest_holder_rewards_with_invalid_destination() {
 
     let mut account = get_account!(context, holder_rewards);
     let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
-    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
-    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+    // "manually" set last accumulated rewards per token to 40_000_000_000_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token =
+        40_000_000 * 1_000_000_000_000_000_000;
 
     account.data = holder_rewards_account.try_to_vec().unwrap();
     context.set_account(&holder_rewards, &account.into());
@@ -972,8 +978,9 @@ async fn sol_staker_stake_harvest_holder_rewards() {
 
     let mut account = get_account!(context, holder_rewards);
     let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
-    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
-    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+    // "manually" set last accumulated rewards per token to 40_000_000_000_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token =
+        40_000_000 * 1_000_000_000_000_000_000;
 
     account.data = holder_rewards_account.try_to_vec().unwrap();
     context.set_account(&holder_rewards, &account.into());
@@ -985,8 +992,8 @@ async fn sol_staker_stake_harvest_holder_rewards() {
     // Calculation:
     //   - total staked: 100
     //   - holder rewards: 4 SOL
-    //   - rewards per token: 4_000_000_000 / 100 = 40_000_000 (0.04 SOL)
-    //   - rewards for 40 staked: 40_000_000 * 40 = 1_600_000_000 (1.6 SOL)
+    //   - rewards per token: 4_000_000_000_000_000_000 / 100 = 40_000_000_000_000_000 (0.04 SOL)
+    //   - rewards for 40 staked: 40_000_000_000_000_000 * 40 = 1_600_000_000_000_000_000 (1.6 SOL)
 
     let destination = Pubkey::new_unique();
 
@@ -1029,7 +1036,7 @@ async fn sol_staker_stake_harvest_holder_rewards() {
     let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         stake_account.delegation.last_seen_holder_rewards_per_token,
-        40_000_000 * 1_000_000_000
+        40_000_000 * 1_000_000_000_000_000_000
     );
 
     // And the vault authority did not keep any lamports (the account should not exist).
@@ -1100,8 +1107,9 @@ async fn sol_staker_stake_harvest_holder_rewards_with_no_rewards_available() {
 
     let mut account = get_account!(context, holder_rewards);
     let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
-    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
-    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+    // "manually" set last accumulated rewards per token to 40_000_000_000_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token =
+        40_000_000 * 1_000_000_000_000_000_000;
 
     account.data = holder_rewards_account.try_to_vec().unwrap();
     context.set_account(&holder_rewards, &account.into());
@@ -1223,8 +1231,9 @@ async fn sol_staker_stake_harvest_holder_rewards_after_harvesting() {
 
     let mut account = get_account!(context, holder_rewards);
     let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
-    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
-    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+    // "manually" set last accumulated rewards per token to 40_000_000_000_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token =
+        40_000_000 * 1_000_000_000_000_000_000;
 
     account.data = holder_rewards_account.try_to_vec().unwrap();
     context.set_account(&holder_rewards, &account.into());
@@ -1303,7 +1312,7 @@ async fn sol_staker_stake_harvest_holder_rewards_after_harvesting() {
     let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         stake_account.delegation.last_seen_holder_rewards_per_token,
-        40_000_000 * 1_000_000_000
+        40_000_000 * 1_000_000_000_000_000_000
     );
 }
 
@@ -1379,8 +1388,9 @@ async fn sol_staker_stake_fail_harvest_holder_rewards_with_wrong_authority() {
 
     let mut account = get_account!(context, holder_rewards);
     let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
-    // "manually" set last accumulated rewards per token to 40_000_000 (0.04 SOL)
-    holder_rewards_account.last_accumulated_rewards_per_token = 40_000_000 * 1_000_000_000;
+    // "manually" set last accumulated rewards per token to 40_000_000_000_000_000 (0.04 SOL)
+    holder_rewards_account.last_accumulated_rewards_per_token =
+        40_000_000 * 1_000_000_000_000_000_000;
 
     account.data = holder_rewards_account.try_to_vec().unwrap();
     context.set_account(&holder_rewards, &account.into());

--- a/clients/rust/tests/harvest_sol_stake_rewards.rs
+++ b/clients/rust/tests/harvest_sol_stake_rewards.rs
@@ -117,7 +117,7 @@ async fn harvest_sol_staker_rewards() {
     let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         stake_account.delegation.last_seen_stake_rewards_per_token,
-        200_000_000 // 0.2 * 1e9
+        200_000_000_000_000_000 // 0.2 * 1e18
     );
 }
 
@@ -371,7 +371,7 @@ async fn harvest_sol_staker_rewards_with_excess_rewards() {
     //   [config account]
     //   - total staked: 26_000_000_000
     //   - stake rewards: 13_000_000_000
-    //   - rewards per token: 13_000_000_000 / 26_000_000_000 = 0.5 SOL
+    //   - rewards per token: 13_000_000_000_000_000_000 / 26_000_000_000 = 0.5 SOL
     //
     //   [harvest]
     //   - rewards for 6_500_000_000 staked, since this is the stake limit:
@@ -416,7 +416,7 @@ async fn harvest_sol_staker_rewards_with_excess_rewards() {
     let stake_account = SolStakerStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         stake_account.delegation.last_seen_stake_rewards_per_token,
-        750_000_000
+        750_000_000_000_000_000
     );
 
     // And the config account has the remaining rewards plus the excess rewards.
@@ -425,7 +425,7 @@ async fn harvest_sol_staker_rewards_with_excess_rewards() {
     let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         config_account.accumulated_stake_rewards_per_token,
-        750_000_000
+        750_000_000_000_000_000
     );
     assert_eq!(
         account.lamports,

--- a/clients/rust/tests/harvest_validator_rewards.rs
+++ b/clients/rust/tests/harvest_validator_rewards.rs
@@ -25,9 +25,9 @@ fn calculate_stake_rewards_per_token(rewards: u64, stake_amount: u64) -> u128 {
     } else {
         // Calculation: rewards / stake_amount
         //
-        // Scaled by 1e9 to store 9 decimal places of precision.
+        // Scaled by 1e18 to store 18 decimal places of precision.
         (rewards as u128)
-            .checked_mul(1_000_000_000)
+            .checked_mul(1_000_000_000_000_000_000)
             .and_then(|product| product.checked_div(stake_amount as u128))
             .unwrap()
     }
@@ -117,7 +117,7 @@ async fn harvest_validator_rewards() {
     let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         stake_account.delegation.last_seen_stake_rewards_per_token,
-        200_000_000 // 0.2 * 1e9
+        200_000_000_000_000_000 // 0.2 * 1e18
     );
 }
 
@@ -212,7 +212,7 @@ async fn harvest_validator_rewards_after_harvesting() {
     // 2 SOL rewards.
     //
     // We simulate that the rewards were already harvested by setting the value of
-    // last_seen_stake_rewards_per_token to the expected rewards_per_token value (0.04 * 1e9).
+    // last_seen_stake_rewards_per_token to the expected rewards_per_token value (0.04 * 1e18).
 
     let validator_stake_manager = ValidatorStakeManager::new(&mut context, &config).await;
 
@@ -567,7 +567,7 @@ async fn harvest_validator_rewards_with_excess_rewards() {
     //   [config account]
     //   - total staked: 26_000_000_000
     //   - stake rewards: 13_000_000_000
-    //   - rewards per token: 13_000_000_000 / 26_000_000_000 = 0.5 SOL
+    //   - rewards per token: 13_000_000_000_000_000_000 / 26_000_000_000 = 0.5 SOL
     //
     //   [harvest]
     //   - rewards for 6_500_000_000 staked, since this is the stake limit:
@@ -611,7 +611,7 @@ async fn harvest_validator_rewards_with_excess_rewards() {
     let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         stake_account.delegation.last_seen_stake_rewards_per_token,
-        750_000_000
+        750_000_000_000_000_000
     );
 
     // And the config account has the remaining rewards plus the excess rewards.
@@ -620,7 +620,7 @@ async fn harvest_validator_rewards_with_excess_rewards() {
     let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
     assert_eq!(
         config_account.accumulated_stake_rewards_per_token,
-        750_000_000
+        750_000_000_000_000_000
     );
     assert_eq!(
         account.lamports,

--- a/clients/rust/tests/setup/mod.rs
+++ b/clients/rust/tests/setup/mod.rs
@@ -15,8 +15,8 @@ pub mod token;
 pub mod validator_stake;
 pub mod vote;
 
-/// Scaling factor for rewards per token (1e9).
-pub const REWARDS_PER_TOKEN_SCALING_FACTOR: u128 = 1_000_000_000;
+/// Scaling factor for rewards per token (1e18).
+pub const REWARDS_PER_TOKEN_SCALING_FACTOR: u128 = 1_000_000_000_000_000_000;
 
 pub fn new_program_test() -> ProgramTest {
     let mut program_test = ProgramTest::new(
@@ -141,9 +141,9 @@ pub fn calculate_stake_rewards_per_token(rewards: u64, stake_amount: u64) -> u12
     } else {
         // Calculation: rewards / stake_amount
         //
-        // Scaled by 1e9 to store 9 decimal places of precision.
+        // Scaled by 1e18 to store 18 decimal places of precision.
         (rewards as u128)
-            .checked_mul(1_000_000_000)
+            .checked_mul(1_000_000_000_000_000_000)
             .and_then(|product| product.checked_div(stake_amount as u128))
             .unwrap()
     }

--- a/clients/rust/tests/setup/mod.rs
+++ b/clients/rust/tests/setup/mod.rs
@@ -143,7 +143,7 @@ pub fn calculate_stake_rewards_per_token(rewards: u64, stake_amount: u64) -> u12
         //
         // Scaled by 1e18 to store 18 decimal places of precision.
         (rewards as u128)
-            .checked_mul(1_000_000_000_000_000_000)
+            .checked_mul(REWARDS_PER_TOKEN_SCALING_FACTOR)
             .and_then(|product| product.checked_div(stake_amount as u128))
             .unwrap()
     }

--- a/program/src/state/config.rs
+++ b/program/src/state/config.rs
@@ -39,8 +39,8 @@ pub struct Config {
 
     /// The current stake rewards per token exchange rate.
     ///
-    /// Stored as a `u128`, which includes a scaling factor of `1e9` to
-    /// represent the exchange rate with 9 decimal places of precision.
+    /// Stored as a `u128`, which includes a scaling factor of `1e18` to
+    /// represent the exchange rate with 18 decimal places of precision.
     pub accumulated_stake_rewards_per_token: PodU128,
 
     /// The maximum proportion that can be deactivated at once, given as basis

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -16,8 +16,8 @@ use solana_program::{
 };
 use std::{mem::size_of, num::NonZeroU64};
 
-/// Scaling factor for rewards per token (1e9).
-const REWARDS_PER_TOKEN_SCALING_FACTOR: u128 = 1_000_000_000;
+/// Scaling factor for rewards per token (1e18).
+const REWARDS_PER_TOKEN_SCALING_FACTOR: u128 = 1_000_000_000_000_000_000;
 
 /// Defined the maximum value for basis points (100%).
 pub const MAX_BASIS_POINTS: u128 = 10_000;
@@ -131,7 +131,7 @@ pub fn calculate_eligible_rewards(
     if marginal_rate == 0 {
         Ok(0)
     } else {
-        // Scaled by 1e9 to store 9 decimal places of precision.
+        // Scaled by 1e18 to store 18 decimal places of precision.
         marginal_rate
             .checked_mul(token_account_balance as u128)
             .and_then(|product| product.checked_div(REWARDS_PER_TOKEN_SCALING_FACTOR))
@@ -149,7 +149,7 @@ pub fn calculate_stake_rewards_per_token(
     } else {
         // Calculation: rewards / stake_amount
         //
-        // Scaled by 1e9 to store 9 decimal places of precision.
+        // Scaled by 1e18 to store 18 decimal places of precision.
         (rewards as u128)
             .checked_mul(REWARDS_PER_TOKEN_SCALING_FACTOR)
             .and_then(|product| product.checked_div(stake_amount as u128))
@@ -214,8 +214,8 @@ mod tests {
 
     #[test]
     fn minimum_stake_rewards_per_token() {
-        // 1 SOL (arithmetic minimum)
-        let minimum_reward = 1_000_000_000;
+        // 1 lamport (arithmetic minimum)
+        let minimum_reward = 1;
         let result = calculate_stake_rewards_per_token(minimum_reward, BENCH_TOKEN_SUPPLY).unwrap();
         assert_ne!(result, 0);
 
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn minimum_eligible_rewards() {
-        // 1 / 1e9 lamports per token
+        // 1 / 1e18 lamports per token
         let minimum_marginal_rewards_per_token = 1;
         let result = calculate_eligible_rewards(
             minimum_marginal_rewards_per_token,
@@ -257,7 +257,7 @@ mod tests {
     #[test]
     fn minimum_eligible_rewards_with_one_token() {
         // 1 / 1e9 lamports per token
-        let minimum_marginal_rewards_per_token = 1;
+        let minimum_marginal_rewards_per_token = 1_000_000_000;
         let result = calculate_eligible_rewards(
             minimum_marginal_rewards_per_token,
             0,
@@ -279,7 +279,7 @@ mod tests {
     #[test]
     fn minimum_eligible_rewards_with_smallest_fractional_token() {
         // 1 lamport per token
-        let minimum_marginal_rewards_per_token = 1_000_000_000;
+        let minimum_marginal_rewards_per_token = 1_000_000_000_000_000_000;
         let result = calculate_eligible_rewards(
             minimum_marginal_rewards_per_token,
             0,


### PR DESCRIPTION
#### Problem
With the program's current scaling factor for "rewards per token" of `1e9`, the minimum reward that will not cause `calculate_rewards_per_token` to return zero is 1 SOL. This is much too high, since small rewards could be paid into the system periodically.

#### Summary of Changes
Increase the scaling factor to `1e18`. This might be considered overkill, but our system can support it, and it also allows the program to capture rewards per token calculations for a minimum reward of 1 lamport.

For more information, see https://github.com/paladin-bladesmith/rewards-program/pull/29.

---

Increasing the scaling to `1e18` does reduce the upper bound of the maximum marginal rate, since within `calculate_eligible_rewards`, we are multiplying the marginal rate by the token account balance. This will be handled in a follow-up PR, where we'll change the checked math to wrapped math.