### PR TITLE
Processor: Use wrapped math

### DIFF
--- a/clients/rust/tests/harvest_holder_rewards.rs
+++ b/clients/rust/tests/harvest_holder_rewards.rs
@@ -162,6 +162,145 @@ async fn validator_stake_harvest_holder_rewards() {
 }
 
 #[tokio::test]
+async fn validator_stake_harvest_holder_rewards_wrapped() {
+    let mut program_test = ProgramTest::new(
+        "paladin_stake_program",
+        paladin_stake_program_client::ID,
+        None,
+    );
+    program_test.add_program(
+        "paladin_rewards_program",
+        paladin_rewards_program_client::ID,
+        None,
+    );
+    let mut context = program_test.start_with_context().await;
+
+    // Given a config account with 100 staked amount.
+
+    let config_manager = ConfigManager::new(&mut context).await;
+
+    let mut account = get_account!(context, config_manager.config);
+    let mut config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the total amount delegated and max reward.
+    config_account.token_amount_delegated = 100;
+    account.data = config_account.try_to_vec().unwrap();
+    context.set_account(&config_manager.config, &account.into());
+
+    // And 4 SOL rewards on its vault account.
+
+    let mut account = get_account!(context, config_manager.vault);
+    account.lamports = account.lamports.saturating_add(4_000_000_000);
+    let rewards_lamports = account.lamports;
+    context.set_account(&config_manager.vault, &account.into());
+
+    // And a stake account wiht a 50 staked amount.
+
+    let stake_manager = ValidatorStakeManager::new(&mut context, &config_manager.config).await;
+
+    let mut account = get_account!(context, stake_manager.stake);
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the amount to 50
+    stake_account.delegation.amount = 50;
+    // Set the stake account's last seen rate to `u128::MAX`.
+    stake_account.delegation.last_seen_holder_rewards_per_token = u128::MAX;
+    account.data = stake_account.try_to_vec().unwrap();
+    context.set_account(&stake_manager.stake, &account.into());
+
+    // And we initialize the holder rewards accounts.
+
+    let holder_rewards_pool = create_holder_rewards_pool(
+        &mut context,
+        &config_manager.mint,
+        &config_manager.mint_authority,
+    )
+    .await;
+
+    let holder_rewards = create_holder_rewards(
+        &mut context,
+        &holder_rewards_pool,
+        &config_manager.mint,
+        &config_manager.vault,
+    )
+    .await;
+
+    let mut account = get_account!(context, holder_rewards);
+    let mut holder_rewards_account = HolderRewards::from_bytes(account.data.as_ref()).unwrap();
+    // Set the vault's last seen rate to 40_000_000 (0.04 SOL), simulating a
+    // scenario where the rate has wrapped around `u128::MAX`.
+    // If the holder's last seen rate is `u128::MAX`, the calculation should
+    // still work with wrapped math.
+    // We have to go just one below 0.04 SOL to cover the wrap around zero.
+    holder_rewards_account.last_accumulated_rewards_per_token =
+        40_000_000 * 1_000_000_000_000_000_000 - 1;
+    account.data = holder_rewards_account.try_to_vec().unwrap();
+    context.set_account(&holder_rewards, &account.into());
+
+    // When we harvest the holder rewards.
+    //
+    // We are expecting the rewards to be 2 SOL.
+    //
+    // Calculation:
+    //   - total staked: 100
+    //   - holder rewards: 4 SOL
+    //   - rewards per token: 4_000_000_000_000_000_000 / 100 = 40_000_000_000_000_000 (0.04 SOL)
+    //   - rewards for 50 staked: 40_000_000_000_000_000 * 50 = 2_000_000_000_000_000_000 (2 SOL)
+
+    let destination = Pubkey::new_unique();
+
+    let harvest_holder_rewards_ix = HarvestHolderRewardsBuilder::new()
+        .config(config_manager.config)
+        .stake(stake_manager.stake)
+        .vault(config_manager.vault)
+        .holder_rewards(holder_rewards)
+        .vault_authority(find_vault_pda(&config_manager.config).0)
+        .stake_authority(stake_manager.authority.pubkey())
+        .destination(destination)
+        .mint(config_manager.mint)
+        .token_program(spl_token_2022::ID)
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[harvest_holder_rewards_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_manager.authority],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Then the destination account has the rewards.
+
+    let account = get_account!(context, destination);
+    assert_eq!(account.lamports, 2_000_000_000);
+
+    // And there should be rewards left on the vault account.
+
+    let account = get_account!(context, config_manager.vault);
+    assert_eq!(
+        account.lamports,
+        rewards_lamports.saturating_sub(2_000_000_000)
+    );
+
+    // And the stake account last seen holder rewards per token is update.
+
+    let account = get_account!(context, stake_manager.stake);
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(
+        stake_account.delegation.last_seen_holder_rewards_per_token,
+        40_000_000 * 1_000_000_000_000_000_000 - 1,
+    );
+
+    // And the vault authority did not keep any lamports (the account should not exist).
+
+    let account = context
+        .banks_client
+        .get_account(find_vault_pda(&config_manager.config).0)
+        .await
+        .unwrap();
+
+    assert!(account.is_none());
+}
+
+#[tokio::test]
 async fn validator_stake_harvest_holder_rewards_with_no_rewards_available() {
     let mut program_test = ProgramTest::new(
         "paladin_stake_program",

--- a/clients/rust/tests/harvest_sol_stake_rewards.rs
+++ b/clients/rust/tests/harvest_sol_stake_rewards.rs
@@ -122,6 +122,112 @@ async fn harvest_sol_staker_rewards() {
 }
 
 #[tokio::test]
+async fn harvest_sol_staker_rewards_wrapped() {
+    let mut context = setup().await;
+
+    // Given a config account with 26 lamports rewards and 130 staked amount.
+
+    let config = create_config(&mut context).await;
+
+    let mut account = get_account!(context, config);
+    let mut config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the total amount delegated
+    config_account.token_amount_delegated = 130;
+    // Set the config account's current rewards per token, simulating a
+    // scenario where the rate has wrapped around `u128::MAX`.
+    // If the holder's last seen rate is `u128::MAX`, the calculation should
+    // still work with wrapped math.
+    config_account.accumulated_stake_rewards_per_token = calculate_stake_rewards_per_token(26, 130);
+
+    account.lamports += 26;
+    account.data = config_account.try_to_vec().unwrap();
+    context.set_account(&config, &account.into());
+
+    // And a validator stake and sol staker stake accounts with 65 staked tokens.
+
+    let validator_stake_manager = ValidatorStakeManager::new(&mut context, &config).await;
+    let sol_staker_stake_manager = SolStakerStakeManager::new(
+        &mut context,
+        &config,
+        &validator_stake_manager.stake,
+        &validator_stake_manager.vote,
+        1_000_000_000,
+    )
+    .await;
+
+    let mut account = get_account!(context, validator_stake_manager.stake);
+    let mut stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the staked values:
+    //   - total staked token = 65
+    //   - total staked lamports = 50
+    stake_account.total_staked_lamports_amount = 50;
+    stake_account.total_staked_token_amount = 65;
+    // Set the stake account's last seen rate to `u128::MAX`.
+    stake_account.delegation.last_seen_stake_rewards_per_token = u128::MAX;
+    account.data = stake_account.try_to_vec().unwrap();
+    context.set_account(&validator_stake_manager.stake, &account.into());
+
+    let mut account = get_account!(context, sol_staker_stake_manager.stake);
+    let mut stake_account = SolStakerStake::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the staked values:
+    //   - delegation amount = 65
+    //   - lamports amount = 50
+    stake_account.delegation.amount = 65;
+    stake_account.lamports_amount = 50;
+    account.data = stake_account.try_to_vec().unwrap();
+    context.set_account(&sol_staker_stake_manager.stake, &account.into());
+
+    // When we harvest the stake rewards.
+    //
+    // We are expecting the rewards to be 13 lamports.
+    //
+    // Calculation:
+    //   - total staked: 130
+    //   - stake rewards: 26 lamports
+    //   - rewards per token: 26 / 130 = 0.2
+    //   - sol staker stake token amount: 65 (limit 1.3 * 50 = 65)
+    //   - rewards for 65 staked: 0.2 * 65 = 13 lamports
+
+    let destination = Pubkey::new_unique();
+    context.set_account(
+        &destination,
+        &AccountSharedData::from(Account {
+            // amount to cover the account rent
+            lamports: 100_000_000,
+            ..Default::default()
+        }),
+    );
+
+    let harvest_stake_rewards_ix = HarvestSolStakerRewardsBuilder::new()
+        .config(config)
+        .sol_staker_stake(sol_staker_stake_manager.stake)
+        .stake_authority(sol_staker_stake_manager.authority.pubkey())
+        .destination(destination)
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[harvest_stake_rewards_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &sol_staker_stake_manager.authority],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Then the destination account has the rewards.
+
+    let account = get_account!(context, destination);
+    assert_eq!(account.lamports, 100_000_000 + 13); // rent + rewards
+
+    // And the stake account has the updated last seen stake rewards per token.
+    let account = get_account!(context, sol_staker_stake_manager.stake);
+    let stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(
+        stake_account.delegation.last_seen_stake_rewards_per_token,
+        200_000_000_000_000_000 // 0.2 * 1e18 - 1
+    );
+}
+
+#[tokio::test]
 async fn harvest_sol_staker_rewards_with_no_rewards_available() {
     let mut context = setup().await;
 

--- a/clients/rust/tests/harvest_sync_rewards.rs
+++ b/clients/rust/tests/harvest_sync_rewards.rs
@@ -356,13 +356,9 @@ async fn harvest_sync_rewards_wrapped() {
         .accumulated_stake_rewards_per_token
         .checked_sub(last_seen_stake_rewards_per_token)
         .and_then(|rewards| {
-            rewards.checked_sub(calculate_stake_rewards_per_token(
-                1_299_000_000,
-                1_300_000_000,
-            ))
+            rewards.checked_sub(calculate_stake_rewards_per_token(1_299_000_000, 1_300_000_000) + 1)
         })
-        .unwrap()
-        - 1;
+        .unwrap();
 
     assert!(difference <= REWARD_PER_TOKEN_ROUNDING_ERROR);
 }

--- a/clients/rust/tests/harvest_sync_rewards.rs
+++ b/clients/rust/tests/harvest_sync_rewards.rs
@@ -198,6 +198,176 @@ async fn harvest_sync_rewards() {
 }
 
 #[tokio::test]
+async fn harvest_sync_rewards_wrapped() {
+    let mut program_test = new_program_test();
+    let vote = add_vote_account(
+        &mut program_test,
+        &Pubkey::new_unique(),
+        &Pubkey::new_unique(),
+    );
+    let mut context = program_test.start_with_context().await;
+    let slot = context.genesis_config().epoch_schedule.first_normal_slot + 1;
+    context.warp_to_slot(slot).unwrap();
+
+    // Given a config, validator stake and sol staker stake accounts with 1 SOL staked.
+
+    // default sync_rewards_lamports = 1_000_000 (0.001 SOL)
+    let config_manager = ConfigManager::new(&mut context).await;
+    let validator_stake_manager =
+        ValidatorStakeManager::new_with_vote(&mut context, &config_manager.config, vote).await;
+    let sol_staker_stake_manager = SolStakerStakeManager::new(
+        &mut context,
+        &config_manager.config,
+        &validator_stake_manager.stake,
+        &validator_stake_manager.vote,
+        1_000_000_000, // 1 SOL staked
+    )
+    .await;
+
+    // And there is 1 SOL for stake rewards on the config.
+
+    let mut account = get_account!(context, config_manager.config);
+    let mut config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the total amount delegated
+    config_account.token_amount_delegated = 1_300_000_000;
+    // Set the config account's current rewards per token, simulating a
+    // scenario where the rate has wrapped around `u128::MAX`.
+    // If the holder's last seen rate is `u128::MAX`, the calculation should
+    // still work with wrapped math.
+    config_account.accumulated_stake_rewards_per_token =
+        calculate_stake_rewards_per_token(1_300_000_000, 1_300_000_000);
+
+    account.lamports += 1_300_000_000; // 1 SOL
+    account.data = config_account.try_to_vec().unwrap();
+    context.set_account(&config_manager.config, &account.into());
+
+    // And the SOL staker stake has 1_300_000_000 tokens staked.
+
+    let mut account = get_account!(context, sol_staker_stake_manager.stake);
+    let mut stake_account = SolStakerStake::from_bytes(account.data.as_ref()).unwrap();
+    // "manually" set the staked values:
+    //   - delegation amount = 1_300_000_000
+    //   - lamports amount = 1_000_000_000
+    stake_account.delegation.amount = 1_300_000_000;
+    stake_account.lamports_amount = 1_000_000_000;
+    // Set the stake account's last seen rate to `u128::MAX`.
+    stake_account.delegation.last_seen_stake_rewards_per_token = u128::MAX;
+    account.data = stake_account.try_to_vec().unwrap();
+    context.set_account(&sol_staker_stake_manager.stake, &account.into());
+
+    // And the SOL staker stake and validator stake accounts are correctly synced.
+
+    let account = get_account!(context, sol_staker_stake_manager.stake);
+    let stake_account = SolStakerStake::from_bytes(account.data.as_ref()).unwrap();
+
+    assert_eq!(stake_account.lamports_amount, 1_000_000_000);
+
+    let account = get_account!(context, validator_stake_manager.stake);
+    let validator_stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(
+        validator_stake_account.total_staked_lamports_amount,
+        1_000_000_000
+    );
+
+    // And we deactivate the stake.
+
+    deactivate_stake_account(
+        &mut context,
+        &stake_account.sol_stake,
+        &sol_staker_stake_manager.authority,
+    )
+    .await;
+
+    // When we harvest rewards for syncing the SOL stake after deactivating the SOL stake.
+
+    let destination = Pubkey::new_unique();
+    context.set_account(
+        &destination,
+        &AccountSharedData::from(Account {
+            // amount to cover the account rent
+            lamports: 100_000_000,
+            ..Default::default()
+        }),
+    );
+
+    let sync_ix = HarvestSyncRewardsBuilder::new()
+        .config(config_manager.config)
+        .sol_staker_stake(sol_staker_stake_manager.stake)
+        .validator_stake(validator_stake_manager.stake)
+        .sol_stake(sol_staker_stake_manager.sol_stake)
+        .destination(destination)
+        .sol_stake_view_program(paladin_sol_stake_view_program_client::ID)
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[sync_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Then the destination account has the sync rewards.
+
+    let account = get_account!(context, destination);
+    assert_eq!(account.lamports, 100_000_000 + 1_000_000); // rent + rewards
+
+    // Then the SOL amounts are correctly synced (0 SOL staked).
+
+    let account = get_account!(context, validator_stake_manager.stake);
+    let validator_stake_account = ValidatorStake::from_bytes(account.data.as_ref()).unwrap();
+    assert_eq!(validator_stake_account.total_staked_lamports_amount, 0);
+
+    let account = get_account!(context, sol_staker_stake_manager.stake);
+    let stake_account = SolStakerStake::from_bytes(account.data.as_ref()).unwrap();
+
+    assert_eq!(stake_account.lamports_amount, 0);
+
+    // And the last seen stake rewards per token on the SOL staker stake account
+    // was updated correctly.
+
+    let last_seen_stake_rewards_per_token =
+        stake_account.delegation.last_seen_stake_rewards_per_token;
+
+    let account = get_account!(context, config_manager.config);
+    let config_account = Config::from_bytes(account.data.as_ref()).unwrap();
+
+    assert!(config_account.accumulated_stake_rewards_per_token > last_seen_stake_rewards_per_token);
+    assert!(last_seen_stake_rewards_per_token > 0);
+
+    // Expected rewards per token:
+    //
+    //  - SOL staker stake's token amount: 1_300_000_000
+    //  - total stake rewards available: 1_300_000_000
+    //  - rewards remanining: 1_300_000_000 - 1_000_000 = 1_299_000_000
+    //    (after the searcher rewards are taken)
+    //
+    //  On the SOL staker stake account:
+    //  - last seen rewards per token: 1_000_000 / 1_300_000_000 - 1
+    //
+    //  Effective rewards per token for SOL stake harvest:
+    //  - rewards per token for SOL stake harvest: 1_299_000_000 / 1_300_000_000
+    assert_eq!(
+        last_seen_stake_rewards_per_token,
+        calculate_stake_rewards_per_token(1_000_000, 1_300_000_000) - 1
+    );
+
+    let difference = config_account
+        .accumulated_stake_rewards_per_token
+        .checked_sub(last_seen_stake_rewards_per_token)
+        .and_then(|rewards| {
+            rewards.checked_sub(calculate_stake_rewards_per_token(
+                1_299_000_000,
+                1_300_000_000,
+            ))
+        })
+        .unwrap()
+        - 1;
+
+    assert!(difference <= REWARD_PER_TOKEN_ROUNDING_ERROR);
+}
+
+#[tokio::test]
 async fn harvest_sync_rewards_without_rewards() {
     let mut program_test = new_program_test();
     let vote = add_vote_account(

--- a/program/src/processor/distribute_rewards.rs
+++ b/program/src/processor/distribute_rewards.rs
@@ -68,9 +68,8 @@ pub fn process_distribute_rewards(
 
     if rewards_per_token != 0 {
         // updates the accumulated stake rewards per token
-        let accumulated = u128::from(config.accumulated_stake_rewards_per_token)
-            .checked_add(rewards_per_token)
-            .ok_or(ProgramError::ArithmeticOverflow)?;
+        let accumulated =
+            u128::from(config.accumulated_stake_rewards_per_token).wrapping_add(rewards_per_token);
         config.accumulated_stake_rewards_per_token = accumulated.into();
     }
 

--- a/program/src/processor/harvest_sync_rewards.rs
+++ b/program/src/processor/harvest_sync_rewards.rs
@@ -188,11 +188,10 @@ pub fn process_harvest_sync_rewards(
             sol_staker_stake
                 .delegation
                 .last_seen_stake_rewards_per_token = last_seen_stake_rewards_per_token
-                .checked_add(calculate_stake_rewards_per_token(
+                .wrapping_add(calculate_stake_rewards_per_token(
                     searcher_rewards,
                     sol_staker_stake.delegation.amount,
                 )?)
-                .ok_or(ProgramError::ArithmeticOverflow)?
                 .into();
 
             // transfer searcher rewards

--- a/program/src/processor/mod.rs
+++ b/program/src/processor/mod.rs
@@ -408,9 +408,7 @@ pub fn process_harvest_for_delegation(
             if rewards_per_token != 0 {
                 // Update the accumulated stake rewards per token on the config to
                 // reflect the addition of the rewards for the exceeding amount.
-                let accumulated = accumulated_rewards_per_token
-                    .checked_add(rewards_per_token)
-                    .ok_or(ProgramError::ArithmeticOverflow)?;
+                let accumulated = accumulated_rewards_per_token.wrapping_add(rewards_per_token);
                 config.accumulated_stake_rewards_per_token = accumulated.into();
             }
         }

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -308,4 +308,30 @@ mod tests {
         )
         .unwrap();
     }
+
+    #[test]
+    fn wrapping_eligible_rewards() {
+        // Set up current to be less than rate, simulating a scenario where the
+        // current reward has wrapped around `u128::MAX`.
+        let current_accumulated_rewards_per_token = 1_000_000_000_000_000_000;
+        let last_accumulated_rewards_per_token = u128::MAX - 1_000_000_000_000_000_000;
+        let result = calculate_eligible_rewards(
+            current_accumulated_rewards_per_token,
+            last_accumulated_rewards_per_token,
+            BENCH_TOKEN_SUPPLY,
+        )
+        .unwrap();
+        assert_ne!(result, 1_000_000_000_000_000_000);
+
+        // Try it again at the very edge. Result should be one.
+        let current_accumulated_rewards_per_token = 0;
+        let last_accumulated_rewards_per_token = u128::MAX;
+        let result = calculate_eligible_rewards(
+            current_accumulated_rewards_per_token,
+            last_accumulated_rewards_per_token,
+            BENCH_TOKEN_SUPPLY,
+        )
+        .unwrap();
+        assert_eq!(result, 1);
+    }
 }

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -321,7 +321,7 @@ mod tests {
             BENCH_TOKEN_SUPPLY,
         )
         .unwrap();
-        assert_ne!(result, 1_000_000_000_000_000_000);
+        assert_eq!(result, 2_000_000_000_000_000_001);
 
         // Try it again at the very edge. Result should be one.
         let current_accumulated_rewards_per_token = 0;

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -124,9 +124,8 @@ pub fn calculate_eligible_rewards(
     //   (current_accumulated_rewards_per_token
     //     - last_accumulated_rewards_per_token)
     //   * token_account_balance
-    let marginal_rate = current_accumulated_rewards_per_token
-        .checked_sub(last_accumulated_rewards_per_token)
-        .ok_or(ProgramError::ArithmeticOverflow)?;
+    let marginal_rate =
+        current_accumulated_rewards_per_token.wrapping_sub(last_accumulated_rewards_per_token);
 
     if marginal_rate == 0 {
         Ok(0)


### PR DESCRIPTION
#### Problem
Whenever any reward system's "accumulated rewards per token" reaches a value of u128::MAX, that system would break and no longer accept any additional rewards paid in. Since we've increased the scaling factor to 1e18, the total system-level rewards paid in over time that would break that system is u128::MAX.

Although this is a pretty large upper bound, we can further increase each system's robustness by using wrapped math for incrementing "accumulated rewards per token" as well as calculating eligible rewards.

#### Summary of Changes
Use wrapped math instead of checked math for incrementing "accumulated rewards per token" in both `DistributeRewards` and `HarvestSyncRewards`, as well as calculating eligible rewards.